### PR TITLE
Update Verifier Installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     python3.8-dev \
     python3.8-venv \
     valgrind \
-    wget \
+    curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/dnnv/_manage/linux/__init__.py
+++ b/dnnv/_manage/linux/__init__.py
@@ -8,8 +8,8 @@ import logging
 from typing import List
 
 from .environment import Environment, ProgramDependency
-from ..errors import *
 from .verifiers import *
+from ..errors import *
 
 
 def install(verifiers: List[str]) -> int:
@@ -46,4 +46,6 @@ __all__ = [
     "install",
     "uninstall",
     "list_verifiers",
-] + verifiers.__all__
+    "import_verifier_module",
+    "verifier_choices",
+]

--- a/dnnv/_manage/linux/environment/__init__.py
+++ b/dnnv/_manage/linux/environment/__init__.py
@@ -2,5 +2,3 @@ from __future__ import annotations
 
 from .base import *
 from .dependencies import *
-
-__all__ = base.__all__ + dependencies.__all__

--- a/dnnv/_manage/linux/environment/dependencies/__init__.py
+++ b/dnnv/_manage/linux/environment/dependencies/__init__.py
@@ -2,5 +2,3 @@ from __future__ import annotations
 
 from .base import *
 from .installers import *
-
-__all__ = base.__all__ + installers.__all__

--- a/dnnv/_manage/linux/environment/dependencies/installers/__init__.py
+++ b/dnnv/_manage/linux/environment/dependencies/installers/__init__.py
@@ -2,5 +2,3 @@ from __future__ import annotations
 
 from .base import *
 from .common import *
-
-__all__ = base.__all__ + common.__all__

--- a/dnnv/_manage/linux/environment/dependencies/installers/common.py
+++ b/dnnv/_manage/linux/environment/dependencies/installers/common.py
@@ -37,7 +37,7 @@ class GNUInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            f"wget -O {identifier}.tar.gz {self.url}",
+            f"curl -o {identifier}.tar.gz -L {self.url}",
             f"tar xf {identifier}.tar.gz",
             f"cd {identifier}",
             f'CFLAGS="{include_paths} {library_paths}" ./configure --prefix={cache_dir}',
@@ -89,7 +89,7 @@ class GurobiInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            f"wget -O {identifier}.tar.gz https://packages.gurobi.com/{major_version}.{minor_version}/gurobi{self.version}_linux64.tar.gz",
+            f"curl -o {identifier}.tar.gz -L https://packages.gurobi.com/{major_version}.{minor_version}/gurobi{self.version}_linux64.tar.gz",
             f"tar xf {identifier}.tar.gz",
             f"cp -r gurobi{nondot_version} {installation_path}/gurobi{nondot_version}",
         ]
@@ -116,7 +116,7 @@ class LpsolveInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            f"wget -O {name}.tar.gz https://downloads.sourceforge.net/project/lpsolve/lpsolve/{self.version}/lp_solve_{self.version}_dev_ux64.tar.gz",
+            f"curl -o {name}.tar.gz -L https://downloads.sourceforge.net/project/lpsolve/lpsolve/{self.version}/lp_solve_{self.version}_dev_ux64.tar.gz",
             f"tar xf {name}.tar.gz",
             "mkdir -p lpsolve",
             "cp *.h lpsolve/",
@@ -144,7 +144,7 @@ class OpenBLASInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            f"wget -O {name}.tar.gz https://github.com/xianyi/OpenBLAS/archive/v{self.version}.tar.gz",
+            f"curl -o {name}.tar.gz -L https://github.com/xianyi/OpenBLAS/archive/v{self.version}.tar.gz",
             f"tar xf {name}.tar.gz",
             f"cd {name}",
             "make",

--- a/dnnv/_manage/linux/verifiers/bab.py
+++ b/dnnv/_manage/linux/verifiers/bab.py
@@ -97,7 +97,9 @@ class BaBInstaller(Installer):
         verifier_venv_path = env.env_dir / "verifier_virtualenvs" / "bab"
         verifier_venv_path.parent.mkdir(exist_ok=True, parents=True)
 
-        gurobi_path = LibraryDependency("libgurobi91").get_path(env).parent.parent
+        libgurobi_path = LibraryDependency("libgurobi91").get_path(env)
+        assert libgurobi_path is not None
+        gurobi_path = libgurobi_path.parent.parent
 
         envvars = env.vars()
         commands = [
@@ -149,6 +151,7 @@ def install(env: Environment):
             installer=BaBInstaller(),
             dependencies=(
                 ProgramDependency("git"),
+                ProgramDependency("curl", min_version="7.16.0"),
                 HeaderDependency("gurobi_c.h", installer=gurobi_installer),
                 LibraryDependency("libgurobi91", installer=gurobi_installer),
                 ProgramDependency("grbgetkey", installer=gurobi_installer),

--- a/dnnv/_manage/linux/verifiers/eran.py
+++ b/dnnv/_manage/linux/verifiers/eran.py
@@ -115,10 +115,17 @@ class ELINAInstaller(Installer):
         library_paths = " ".join(f"-L{p}" for p in env.ld_library_paths)
         include_paths = " ".join(f"-I{p}" for p in env.include_paths)
 
-        mpfr_path = LibraryDependency("libmpfr").get_path(env).parent.parent
-        gmp_path = LibraryDependency("libgmp").get_path(env).parent.parent
-        # cdd_path = LibraryDependency("libcdd").get_path(env).parent.parent
-        cdd_prefix = HeaderDependency("cddlib/cdd.h").get_path(env).parent
+        libmpfr_path = LibraryDependency("libmpfr").get_path(env)
+        assert libmpfr_path is not None
+        mpfr_path = libmpfr_path.parent.parent
+
+        libgmp_path = LibraryDependency("libgmp").get_path(env)
+        assert libgmp_path is not None
+        gmp_path = libgmp_path.parent.parent
+
+        cdd_h_path = HeaderDependency("cddlib/cdd.h").get_path(env)
+        assert cdd_h_path is not None
+        cdd_prefix = cdd_h_path.parent
 
         envvars = env.vars()
         commands = [
@@ -165,8 +172,13 @@ class ERANInstaller(Installer):
         verifier_venv_path = env.env_dir / "verifier_virtualenvs" / name
         verifier_venv_path.parent.mkdir(exist_ok=True, parents=True)
 
-        gurobi_path = LibraryDependency("libgurobi91").get_path(env).parent.parent
-        elina_path = LibraryDependency("libzonoml").get_path(env).parent.parent
+        libgurobi_path = LibraryDependency("libgurobi91").get_path(env)
+        assert libgurobi_path is not None
+        gurobi_path = libgurobi_path.parent.parent
+
+        libzonoml_path = LibraryDependency("libzonoml").get_path(env)
+        assert libzonoml_path is not None
+        elina_path = libzonoml_path.parent.parent
 
         python_major_version, python_minor_version = sys.version_info[:2]
 
@@ -230,6 +242,7 @@ def install(env: Environment):
             installer=ERANInstaller(),
             dependencies=(
                 ProgramDependency("git"),
+                ProgramDependency("curl", min_version="7.16.0"),
                 HeaderDependency("gurobi_c.h", installer=gurobi_installer),
                 LibraryDependency("libgurobi91", installer=gurobi_installer),
                 ProgramDependency("grbgetkey", installer=gurobi_installer),

--- a/dnnv/_manage/linux/verifiers/marabou.py
+++ b/dnnv/_manage/linux/verifiers/marabou.py
@@ -89,7 +89,9 @@ class MarabouInstaller(Installer):
         verifier_venv_path = env.env_dir / "verifier_virtualenvs" / "marabou"
         verifier_venv_path.parent.mkdir(exist_ok=True, parents=True)
 
-        openblas_path = LibraryDependency("libopenblas").get_path(env).parent.parent
+        libopenblas_path = LibraryDependency("libopenblas").get_path(env)
+        assert libopenblas_path is not None
+        openblas_path = libopenblas_path.parent.parent
 
         python_major_version, python_minor_version = sys.version_info[:2]
 
@@ -132,8 +134,15 @@ def install(env: Environment):
             "marabou",
             installer=MarabouInstaller(),
             dependencies=(
+                ProgramDependency("make"),
+                ProgramDependency("gcc"),
                 ProgramDependency("git"),
-                LibraryDependency("libopenblas", installer=OpenBLASInstaller("0.3.9")),
+                ProgramDependency("curl", min_version="7.16.0"),
+                LibraryDependency(
+                    "libopenblas",
+                    installer=OpenBLASInstaller("0.3.9"),
+                    allow_from_system=False,
+                ),
                 ProgramDependency(
                     "cmake",
                     installer=GNUInstaller(
@@ -141,6 +150,7 @@ def install(env: Environment):
                         "3.18.2",
                         "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz",
                     ),
+                    min_version="3.12.0",
                 ),
             ),
         )

--- a/dnnv/_manage/linux/verifiers/mipverify.py
+++ b/dnnv/_manage/linux/verifiers/mipverify.py
@@ -34,7 +34,9 @@ class MIPVerifyInstaller(Installer):
         installation_path = env.env_dir / "bin"
         installation_path.mkdir(exist_ok=True, parents=True)
 
-        julia_dir = LibraryDependency("libjulia").get_path(env).parent.parent
+        libjulia_path = LibraryDependency("libjulia").get_path(env)
+        assert libjulia_path is not None
+        julia_dir = libjulia_path.parent.parent
 
         envvars = env.vars()
         commands = [
@@ -84,7 +86,7 @@ class JuliaInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            f"wget -O julia-{version}.tar.gz https://julialang-s3.julialang.org/bin/linux/x64/{major_minor}/julia-{version}-linux-x86_64.tar.gz",
+            f"curl -o julia-{version}.tar.gz -L https://julialang-s3.julialang.org/bin/linux/x64/{major_minor}/julia-{version}-linux-x86_64.tar.gz",
             f"tar xf julia-{version}.tar.gz",
         ]
         install_script = "; ".join(commands)

--- a/dnnv/_manage/linux/verifiers/neurify.py
+++ b/dnnv/_manage/linux/verifiers/neurify.py
@@ -47,6 +47,7 @@ class NeurifyInstaller(Installer):
 
 def install(env: Environment):
     lpsolve_installer = LpsolveInstaller("5.5.2.5")
+    openblas_installer = OpenBLASInstaller("0.3.9")
     env.ensure_dependencies(
         ProgramDependency(
             "neurify",
@@ -55,9 +56,11 @@ def install(env: Environment):
                 ProgramDependency("make"),
                 ProgramDependency("gcc"),
                 ProgramDependency("git"),
+                ProgramDependency("curl", min_version="7.16.0"),
                 HeaderDependency("lpsolve/lp_lib.h", installer=lpsolve_installer),
                 LibraryDependency("liblpsolve55", installer=lpsolve_installer),
-                LibraryDependency("libopenblas", installer=OpenBLASInstaller("0.3.9")),
+                HeaderDependency("cblas.h", installer=openblas_installer),
+                LibraryDependency("libopenblas", installer=openblas_installer),
             ),
         )
     )

--- a/dnnv/_manage/linux/verifiers/planet.py
+++ b/dnnv/_manage/linux/verifiers/planet.py
@@ -74,6 +74,7 @@ def install(env: Environment):
                 ProgramDependency("make"),
                 ProgramDependency("gcc"),
                 ProgramDependency("git"),
+                ProgramDependency("curl", min_version="7.16.0"),
                 HeaderDependency(
                     "gmp.h",
                     installer=gmp_installer,

--- a/dnnv/_manage/linux/verifiers/verinet.py
+++ b/dnnv/_manage/linux/verifiers/verinet.py
@@ -98,7 +98,9 @@ class VeriNetInstaller(Installer):
         verifier_venv_path = env.env_dir / "verifier_virtualenvs" / name
         verifier_venv_path.parent.mkdir(exist_ok=True, parents=True)
 
-        gurobi_path = LibraryDependency("libgurobi91").get_path(env).parent.parent
+        libgurobi_path = LibraryDependency("libgurobi91").get_path(env)
+        assert libgurobi_path is not None
+        gurobi_path = libgurobi_path.parent.parent
 
         python_major_version, python_minor_version = sys.version_info[:2]
 
@@ -115,7 +117,7 @@ class VeriNetInstaller(Installer):
             "python setup.py install",
             f"cd {cache_dir}",
             f"rm -rf {name}",
-            f"wget https://github.com/dlshriver/DNNV/archive/refs/tags/{dnnv_version}.tar.gz",
+            f"curl -O -L https://github.com/dlshriver/DNNV/archive/refs/tags/{dnnv_version}.tar.gz",
             f"tar xf {dnnv_version}.tar.gz --wildcards */third_party/VeriNet --strip-components=2",
             f"cp -r VeriNet/src {verifier_venv_path}/lib/python{python_major_version}.{python_minor_version}/site-packages/",
         ]


### PR DESCRIPTION
This updates the verifier installation scripts to use curl instead of wget and enables the specification of minimum version numbers for program dependencies. These changes should help to get around some installation issues encountered on some systems.