### PR TITLE
Fixing bugs in IfThenElse behavior

### DIFF
--- a/dnnv/properties/transformers/dnf.py
+++ b/dnnv/properties/transformers/dnf.py
@@ -33,13 +33,17 @@ class DnfTransformer(GenericExpressionTransformer):
         expressions: Set[Expression] = set()
         for expr in expression.expressions:
             expr = self.visit(expr)
+            if expr.is_concrete:
+                if expr.value:
+                    continue
+                return Constant(False)
             if disjunction is None and isinstance(expr, Or):
                 disjunction = expr
             else:
                 expressions.add(expr)
         if disjunction is None:
             if len(expressions) == 0:
-                return Constant(False)
+                return Constant(True)
             return Or(And(*expressions))
         elif len(expressions) == 0:
             return disjunction
@@ -144,6 +148,10 @@ class DnfTransformer(GenericExpressionTransformer):
         expressions: Set[Expression] = set()
         for expr in expression.expressions:
             expr = self.visit(expr)
+            if expr.is_concrete:
+                if expr.value:
+                    return Constant(True)
+                continue
             if isinstance(expr, Or):
                 expressions = expressions.union(expr.expressions)
             else:

--- a/dnnv/properties/transformers/lift_ifthenelse.py
+++ b/dnnv/properties/transformers/lift_ifthenelse.py
@@ -38,15 +38,15 @@ class LiftIfThenElse(GenericExpressionTransformer):
             else:
                 expressions.append(expr)
         if len(ite_exprs) > 1:
-            t_expr = self.visit_AssociativeExpression(
+            t_expr = self.visit(
                 expr_t(ite_exprs[0].t_expr, *ite_exprs[1:], *expressions)
             )
-            f_expr = self.visit_AssociativeExpression(
+            f_expr = self.visit(
                 expr_t(ite_exprs[0].f_expr, *ite_exprs[1:], *expressions)
             )
         else:
-            t_expr = expr_t(ite_exprs[0].t_expr, *expressions)
-            f_expr = expr_t(ite_exprs[0].f_expr, *expressions)
+            t_expr = self.visit(expr_t(ite_exprs[0].t_expr, *expressions))
+            f_expr = self.visit(expr_t(ite_exprs[0].f_expr, *expressions))
         return IfThenElse(ite_exprs[0].condition, t_expr, f_expr)
 
     def visit_BinaryExpression(

--- a/tests/unit_tests/test_properties/test_transformers/test_CanonicalTransformer/test_Equal.py
+++ b/tests/unit_tests/test_properties/test_transformers/test_CanonicalTransformer/test_Equal.py
@@ -33,11 +33,4 @@ def test_Equal_constants():
 
     expr = Equal(Constant(302), Constant(120))
     new_expr = transformer.visit(expr)
-    assert new_expr is not expr
-    assert isinstance(new_expr, Or)
-    new_expr_add = new_expr
-    assert len(new_expr_add.expressions) == 1
-    assert isinstance(new_expr.expressions[0], And)
-    assert len(new_expr.expressions[0].expressions) == 2
-    assert LessThanOrEqual(Add(), Constant(-182)) in new_expr.expressions[0].expressions
-    assert LessThanOrEqual(Add(), Constant(182)) in new_expr.expressions[0].expressions
+    assert new_expr is Constant(False)

--- a/tests/unit_tests/test_properties/test_transformers/test_CanonicalTransformer/test_Multiply.py
+++ b/tests/unit_tests/test_properties/test_transformers/test_CanonicalTransformer/test_Multiply.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+from dnnv.nn.utils import TensorDetails
 from dnnv.properties import *
 from dnnv.properties.transformers import CanonicalTransformer
 
@@ -49,3 +52,57 @@ def test_Multiply_mixed_additions():
     assert Multiply(Constant(1), Symbol("b")) in new_expr
     assert Multiply(Constant(1), Symbol("a"), Symbol("b")) in new_expr
     assert Multiply(Constant(1), Symbol("a"), Symbol("a")) in new_expr
+
+
+def test_samysweb_property_3():
+    # based on property 3 of issue https://github.com/dlshriver/dnnv/issues/75
+    transformer = CanonicalTransformer()
+
+    x_ = Symbol("x_")
+    N = Network("N")
+    fake_network = lambda x: np.array([[0]])
+    fake_network.input_details = (TensorDetails((1, 2), np.float32),)
+    fake_network.input_shape = ((1, 2),)
+    fake_network.output_details = (TensorDetails((1, 1), np.float32),)
+    fake_network.output_shape = ((1, 1),)
+    N.concretize(fake_network)
+
+    expr = Not(
+        Or(
+            (
+                Constant(0.0)
+                >= IfThenElse(
+                    Constant(0.0) > x_[0, 1],
+                    (Constant(0.16) * x_[0, 0] + Constant(-0.16) * x_[0, 0]),
+                    x_[0, 1],
+                )
+            ),
+            And(x_[0, 1] == Constant(0.0), N(x_) == Constant(0.0)),
+        )
+    )
+
+    new_expr = transformer.visit(expr).propagate_constants()
+    assert new_expr is not expr
+    assert new_expr.is_equivalent(
+        Or(
+            And(
+                LessThan(Multiply(-1, Network("N")(Symbol("x_"))), Constant(0)),
+                LessThan(Multiply(-1, Symbol("x_")[(0, 1)]), Constant(0)),
+                LessThanOrEqual(Multiply(-1, Symbol("x_")[(0, 1)]), Constant(0)),
+            ),
+            And(
+                LessThan(Multiply(-1, Symbol("x_")[(0, 1)]), Constant(0)),
+                LessThan(Network("N")(Symbol("x_")), Constant(0)),
+                LessThanOrEqual(Multiply(-1, Symbol("x_")[(0, 1)]), Constant(0)),
+            ),
+            And(
+                LessThan(Multiply(-1, Symbol("x_")[(0, 1)]), Constant(0)),
+                LessThan(Symbol("x_")[(0, 1)], Constant(0)),
+                LessThanOrEqual(Multiply(-1, Symbol("x_")[(0, 1)]), Constant(0)),
+            ),
+            And(
+                LessThan(Multiply(-1, Symbol("x_")[(0, 1)]), Constant(0)),
+                LessThanOrEqual(Multiply(-1, Symbol("x_")[(0, 1)]), Constant(0)),
+            ),
+        )
+    )

--- a/tests/unit_tests/test_properties/test_transformers/test_CanonicalTransformer/test_NotEqual.py
+++ b/tests/unit_tests/test_properties/test_transformers/test_CanonicalTransformer/test_NotEqual.py
@@ -39,11 +39,4 @@ def test_NotEqual_constants():
 
     expr = NotEqual(Constant(302), Constant(120))
     new_expr = transformer.visit(expr)
-    assert new_expr is not expr
-    assert isinstance(new_expr, Or)
-    assert len(new_expr.expressions) == 2
-    assert isinstance(new_expr.expressions[0], And)
-    assert len(new_expr.expressions[0].expressions) == 1
-    or_expressions = new_expr.expressions
-    assert And(GreaterThan(Add(), Constant(-182))) in or_expressions
-    assert And(GreaterThan(Add(), Constant(182))) in or_expressions
+    assert new_expr is Constant(True)

--- a/tests/unit_tests/test_properties/test_transformers/test_DnfTransformer/test_And.py
+++ b/tests/unit_tests/test_properties/test_transformers/test_DnfTransformer/test_And.py
@@ -9,7 +9,7 @@ def test_And_empty():
     expr = And()
     new_expr = transformer.visit(expr)
     assert new_expr is not expr
-    assert new_expr is Constant(False)
+    assert new_expr is Constant(True)
 
 
 def test_And_of_and():

--- a/tests/unit_tests/test_properties/test_visitors/test_DetailsInference/test_IfThenElse.py
+++ b/tests/unit_tests/test_properties/test_visitors/test_DetailsInference/test_IfThenElse.py
@@ -61,17 +61,15 @@ def test_IfThenElse_constant_true_expr():
 
     assert inference.types[c].is_concrete
     assert inference.types[t].is_concrete
-    assert inference.types[f].is_concrete
-    assert inference.types[expr].is_concrete
+    assert not inference.types[f].is_concrete
+    assert not inference.types[expr].is_concrete
 
     assert inference.shapes[c].value == ()
     assert inference.types[c].value == bool
     assert inference.shapes[t].value == t.value.shape
     assert inference.types[t].value == t.value.dtype
     assert inference.shapes[f].value == t.value.shape
-    assert inference.types[f].value == t.value.dtype
     assert inference.shapes[expr].value == t.value.shape
-    assert inference.types[expr].value == t.value.dtype
 
 
 def test_IfThenElse_constant_false_expr():
@@ -87,18 +85,45 @@ def test_IfThenElse_constant_false_expr():
     assert inference.shapes[expr].is_concrete
 
     assert inference.types[c].is_concrete
+    assert not inference.types[t].is_concrete
+    assert inference.types[f].is_concrete
+    assert not inference.types[expr].is_concrete
+
+    assert inference.shapes[c].value == ()
+    assert inference.types[c].value == bool
+    assert inference.shapes[t].value == f.value.shape
+    assert inference.shapes[f].value == f.value.shape
+    assert inference.types[f].value == f.value.dtype
+    assert inference.shapes[expr].value == f.value.shape
+
+
+def test_IfThenElse_constant_true_false_expr():
+    inference = DetailsInference()
+
+    c, t, f = Symbol("c"), Constant(1), Constant(np.array(1.0))
+    expr = IfThenElse(c, t, f)
+    inference.visit(expr)
+
+    assert inference.shapes[c].is_concrete
+    assert inference.shapes[t].is_concrete
+    assert inference.shapes[f].is_concrete
+    assert inference.shapes[expr].is_concrete
+
+    assert inference.types[c].is_concrete
     assert inference.types[t].is_concrete
     assert inference.types[f].is_concrete
     assert inference.types[expr].is_concrete
 
     assert inference.shapes[c].value == ()
     assert inference.types[c].value == bool
-    assert inference.shapes[t].value == f.value.shape
-    assert inference.types[t].value == f.value.dtype
+    assert inference.shapes[t].value == ()
+    assert inference.types[t].value == np.min_scalar_type(t.value)
     assert inference.shapes[f].value == f.value.shape
     assert inference.types[f].value == f.value.dtype
     assert inference.shapes[expr].value == f.value.shape
-    assert inference.types[expr].value == f.value.dtype
+    assert inference.types[expr].value == np.result_type(
+        np.min_scalar_type(t.value), f.value.dtype
+    )
 
 
 def test_IfThenElse_incompatible_shapes():
@@ -123,16 +148,6 @@ def test_IfThenElse_incompatible_shapes():
 
 def test_IfThenElse_incompatible_types():
     inference = DetailsInference()
-
-    with get_context():
-        c, t, f = (
-            Symbol("c"),
-            Constant(np.random.rand(3, 5)),
-            Constant(np.random.rand(3, 5) > 0.5),
-        )
-        expr = IfThenElse(c, t, f)
-        with pytest.raises(DNNVTypeError):
-            inference.visit(expr)
 
     with get_context():
         c, t, f = Constant(8), Symbol("true"), Symbol("false")


### PR DESCRIPTION
This fixes a bug in the transformer for lifting IfThenElse expresssions out of subexpressions, a bug in type inference for IfThenElse expressions, and an indexing bug in the Multiply visitor of the CanonicalTransformer. These were all reported in #75.