### PR TITLE
Hashing Performance

### DIFF
--- a/dnnv/properties/expressions/base.py
+++ b/dnnv/properties/expressions/base.py
@@ -32,7 +32,7 @@ class Expression:
 
     def __init__(self, ctx: Optional[Context] = None):
         self.ctx: Context = ctx or get_context()
-        self.hash_cache_base = None
+        self._hash_cache_base = None
 
     def __bool__(self):
         if self.is_concrete:
@@ -40,12 +40,12 @@ class Expression:
         raise ValueError("The truth value of a non-concrete expression is ambiguous")
 
     def __hash__(self) -> int:
-        if self.hash_cache_base is None:
+        if self._hash_cache_base is None:
             exprs_hash = 1
             for expr in self.iter(max_depth=1, include_self=False):
                 exprs_hash *= hash(expr)
-            self.hash_cache_base =  hash(self.__class__) * exprs_hash
-        return self.hash_cache_base
+            self._hash_cache_base =  hash(self.__class__) * exprs_hash
+        return self._hash_cache_base
 
     def __getattr__(self, name) -> Union[Attribute, Constant]:
         from .attribute import Attribute

--- a/dnnv/properties/expressions/base.py
+++ b/dnnv/properties/expressions/base.py
@@ -32,6 +32,7 @@ class Expression:
 
     def __init__(self, ctx: Optional[Context] = None):
         self.ctx: Context = ctx or get_context()
+        self.hash_cache_base = None
 
     def __bool__(self):
         if self.is_concrete:
@@ -39,10 +40,12 @@ class Expression:
         raise ValueError("The truth value of a non-concrete expression is ambiguous")
 
     def __hash__(self) -> int:
-        exprs_hash = 1
-        for expr in self.iter(max_depth=1, include_self=False):
-            exprs_hash *= hash(expr)
-        return hash(self.__class__) * exprs_hash
+        if self.hash_cache_base is None:
+            exprs_hash = 1
+            for expr in self.iter(max_depth=1, include_self=False):
+                exprs_hash *= hash(expr)
+            self.hash_cache_base =  hash(self.__class__) * exprs_hash
+        return self.hash_cache_base
 
     def __getattr__(self, name) -> Union[Attribute, Constant]:
         from .attribute import Attribute

--- a/dnnv/properties/expressions/call.py
+++ b/dnnv/properties/expressions/call.py
@@ -27,7 +27,7 @@ class Call(CallableExpression, ArithmeticExpression, LogicalExpression):
         self.args = args
         self.kwargs = kwargs
         self._value = None
-        self.hash_cache_call = None
+        self._hash_cache_call = None
 
     @property
     def value(self):
@@ -60,14 +60,14 @@ class Call(CallableExpression, ArithmeticExpression, LogicalExpression):
         return False
 
     def __hash__(self):
-        if self.hash_cache_call is None:
+        if self._hash_cache_call is None:
             args_hash = 1
             for arg in self.args:
                 args_hash *= hash(arg)
             for key, arg in self.kwargs.items():
                 args_hash *= hash(key) * hash(arg)
-            self.hash_cache_call = super().__hash__() * hash(self.function) * args_hash
-        return self.hash_cache_call
+            self._hash_cache_call = super().__hash__() * hash(self.function) * args_hash
+        return self._hash_cache_call
 
     def __repr__(self):
         function_name = repr(self.function)

--- a/dnnv/properties/expressions/call.py
+++ b/dnnv/properties/expressions/call.py
@@ -27,6 +27,7 @@ class Call(CallableExpression, ArithmeticExpression, LogicalExpression):
         self.args = args
         self.kwargs = kwargs
         self._value = None
+        self.hash_cache_call = None
 
     @property
     def value(self):
@@ -59,12 +60,14 @@ class Call(CallableExpression, ArithmeticExpression, LogicalExpression):
         return False
 
     def __hash__(self):
-        args_hash = 1
-        for arg in self.args:
-            args_hash *= hash(arg)
-        for key, arg in self.kwargs.items():
-            args_hash *= hash(key) * hash(arg)
-        return super().__hash__() * hash(self.function) * args_hash
+        if self.hash_cache_call is None:
+            args_hash = 1
+            for arg in self.args:
+                args_hash *= hash(arg)
+            for key, arg in self.kwargs.items():
+                args_hash *= hash(key) * hash(arg)
+            self.hash_cache_call = super().__hash__() * hash(self.function) * args_hash
+        return self.hash_cache_call
 
     def __repr__(self):
         function_name = repr(self.function)


### PR DESCRIPTION
Hello,

I've recently made a fork from your tool where I'm trying to generate whole sets of counter-examples instead of single instances (still under development).

While attempting to check a more complex property containing multiple if statements (see [attachment property.txt](https://github.com/dlshriver/dnnv/files/8006911/property.txt)),
I noticed that the analysis prior to the NN Verification queries took exceptionally long.
While I did expect it to take some time (the final DNF had some 9500 conjunctions), I was surprised by the amount of time that `DetailInference` and DNF generation (the second time measurements is the call to `super().visit(expression)` in `DnfTransformer`) in  took:
```
INFO     2022-02-04 13:24:33,404 (dnnv.properties.visitors.base) [TIME] Details Inference took 1177.590128660202 seconds
INFO     2022-02-04 13:26:26,147 (dnnv.properties.visitors.base) [TIME] Super Visit took 112.74267172813416 seconds
```

Further digging into the problem, I ran some profiling on the execution and noted, that the hashing on the expressions (necessary for the dictionaries) takes up a significant portion of the overall time spent.
Each call isn't even that expensive, but these functions are called extremely often:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
6365047/32030    9.284    0.000   62.203    0.002 .../DNNV/.venv/lib/python3.7/site-packages/dnnv/properties/expressions/base.py:41(__hash__)
908417/31112    2.984    0.000   54.825    0.002 .../DNNV/.venv/lib/python3.7/site-packages/dnnv/properties/expressions/call.py:61(__hash__)
  4740705    5.891    0.000   35.426    0.000 .../DNNV/.venv/lib/python3.7/site-packages/dnnv/properties/expressions/terms/constant.py:59(__hash__)
   232813    0.286    0.000    1.607    0.000 .../DNNV/.venv/lib/python3.7/site-packages/dnnv/properties/expressions/terms/symbol.py:38(__hash__)
    23350    0.008    0.000    0.012    0.000 .../DNNV/.venv/lib/python3.7/site-packages/lark/grammar.py:25(__hash__)
....
```

Noting that `base` and `call` both have quite complex hash functions, I tried introducing caching variables which store the hash value after its first computation.

This lead to a drastic decline of the time taken for inference and dnf generation:
```
INFO     2022-02-04 16:53:23,184 (dnnv.properties.visitors.base) [TIME] Details Inference took 0.6102278232574463 seconds
INFO     2022-02-04 16:53:25,471 (dnnv.properties.visitors.base) [TIME] Super Visit took 2.2868947982788086 seconds
```

While these timed experiments took place on my personal branch, I am pretty sure you should see significant speedups on any  (more complex) properties on any branch.

I was thinking you might possibly be interested in adding this optimization to your tool...