### PR TITLE
Fixed bound monotonicity bug

### DIFF
--- a/dnnv/verifiers/common/reductions/iopolytope/base.py
+++ b/dnnv/verifiers/common/reductions/iopolytope/base.py
@@ -103,8 +103,12 @@ class HalfspacePolytope(Constraint):
         self._b: List[np.ndarray] = []
         self._A_mat: Optional[np.ndarray] = None
         self._b_vec: Optional[np.ndarray] = None
-        self._lower_bound = np.full(self.size(), -np.inf)
-        self._upper_bound = np.full(self.size(), np.inf)
+        if np.isscalar(self.size()):
+            shape = self.size()
+        else:
+            shape = self.size()[::-1]
+        self._lower_bound = np.full(shape, -np.inf)
+        self._upper_bound = np.full(shape, np.inf)
 
     @property
     def A(self) -> np.ndarray:

--- a/dnnv/verifiers/common/reductions/iopolytope/base.py
+++ b/dnnv/verifiers/common/reductions/iopolytope/base.py
@@ -103,12 +103,8 @@ class HalfspacePolytope(Constraint):
         self._b: List[np.ndarray] = []
         self._A_mat: Optional[np.ndarray] = None
         self._b_vec: Optional[np.ndarray] = None
-        if np.isscalar(self.size()):
-            shape = self.size()
-        else:
-            shape = self.size()[::-1]
-        self._lower_bound = np.full(shape, -np.inf)
-        self._upper_bound = np.full(shape, np.inf)
+        self._lower_bound = np.full(self.size(), -np.inf)
+        self._upper_bound = np.full(self.size(), np.inf)
 
     @property
     def A(self) -> np.ndarray:
@@ -226,11 +222,17 @@ class HalfspacePolytope(Constraint):
                 obj = np.zeros(n)
                 try:
                     obj[i] = 1
+                    bounds = list(
+                        zip(
+                            (l for l in self._lower_bound),
+                            (u for u in self._upper_bound),
+                        )
+                    )
                     result = linprog(
                         obj,
                         A_ub=self.A,
                         b_ub=self.b,
-                        bounds=(None, None),
+                        bounds=bounds,
                         method="highs",
                     )
                     if result.status == 0:
@@ -243,11 +245,17 @@ class HalfspacePolytope(Constraint):
                         raise e
                 try:
                     obj[i] = -1
+                    bounds = list(
+                        zip(
+                            (l for l in self._lower_bound),
+                            (u for u in self._upper_bound),
+                        )
+                    )
                     result = linprog(
                         obj,
                         A_ub=self.A,
                         b_ub=self.b,
-                        bounds=(None, None),
+                        bounds=bounds,
                         method="highs",
                     )
                     if result.status == 0:

--- a/tests/unit_tests/test_verifiers/test_common/test_reductions/test_iopolytope/test_IOPolytopeReduction.py
+++ b/tests/unit_tests/test_verifiers/test_common/test_reductions/test_iopolytope/test_IOPolytopeReduction.py
@@ -59,3 +59,68 @@ def test_simple_property():
 
     assert np.all(prop.output_constraint._lower_bound == np.array([np.nextafter(0, 1)]))
     assert np.all(prop.output_constraint._upper_bound == np.array([np.inf]))
+
+def test_bounds_monotonous():
+    """
+    If we initiate the bounds for a certain upper and lower bound, the lower/upper bound may only
+    increase/decrease.
+    """
+    reduction = IOPolytopeReduction(HalfspacePolytope)
+
+    # Example with bounds initialized to [0, -200] [100,100]
+    phi = Exists(
+        Symbol("x"),
+        And(
+            ((Constant(-0.014999999999981656) * Subscript(Symbol("x"),Constant((0,1)))) < Constant(1.4999999999926625)),
+            And(
+                (((Constant(-0.007499999999983742) * Subscript(Symbol("x"),Constant((0,1))))) < Constant(0.4999999999967484)),
+                And(
+                    (((Constant(0.0075000000000270415) * Subscript(Symbol("x"),Constant((0,1))))) <= Constant(0.500000000000365)),
+                    And(
+                        (((Constant(-0.007499999999983742) * Subscript(Symbol("x"),Constant((0,1))))) <= Constant(1.4999999999967484)),
+                        And(
+                            (((1 * Subscript(Symbol("x"),Constant((0,0)))) + (Constant(-0.13574999999783516) * Subscript(Symbol("x"),Constant((0,1))))) < Constant(47.64999999956703)),
+                            And(
+                                (((1 * Network("N")(Symbol("x")))) < Constant(100.0)),
+                                And(
+                                    (((-1 * Symbol("x"))) <= np.array([[ 0, 200]])),
+                                    And(
+                                        (((Constant(0.015000000000010782) * Subscript(Symbol("x"),Constant((0,1))))) <= Constant(-0.9999999999963833)),
+                                        And(
+                                            (((1 * Symbol("x"))) <= np.array([[100, 100]])),
+                                            And(
+                                                (((-1 * Subscript(Symbol("x"),Constant((0,0)))) + (Constant(0.010000000000036688) * Subscript(Symbol("x"),Constant((0,1))))) <= Constant(1.0)),
+                                                And(
+                                                    (((1 * Subscript(Symbol("x"),Constant((0,1))))) < 0),
+                                                    And(
+                                                        (((Constant(-0.014999999999981656) * Subscript(Symbol("x"),Constant((0,1))))) < Constant(1.4999999999926625)),
+                                                        And(
+                                                            (((Constant(0.005000000000018344) * Subscript(Symbol("x"),Constant((0,1))))) <= Constant(0.5)),
+                                                            (((Constant(-0.009999999999963313) * Subscript(Symbol("x"),Constant((0,1))))) < Constant(0.9999999999926624))
+                                                        )
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+    input_op = operations.Input((1,2), np.dtype(np.float64))
+    output_op = operations.Add(input_op, operations.Mul(np.float64(-2), input_op))
+    op_graph = OperationGraph([output_op])
+    phi.concretize(N=op_graph)
+
+    properties = list(reduction.reduce_property(phi))
+    assert len(properties) == 1
+    prop = properties[0]
+
+    assert len(prop.networks) == 1
+
+    assert np.all(prop.input_constraint._lower_bound >= np.array([0, -200]))
+    assert np.all(prop.input_constraint._upper_bound <= np.array([100,100]))


### PR DESCRIPTION
Hello,
I noticed that `NNEnum` would sometimes return counter-examples outside the provided input constraints.
At first I thought this was a problem with `NNEnum`, however there was actually a small bug in the bounds computation procedure which did not consider previous bounds when computing the new ones.
Essentially, when adding constraints, the lower/upper bounds should increase/decrease monotonously.
Instead, in some cases the lower bound would sometimes decrease or the upper bound would increase upon adding a constraint.

I fixed this issue and provided a test case which shows this behaviour:
The two input variables should (according to given constraints) be in the interval [0,-200]x[100,100], however before the fix the lower bound of x_1 would drop below 0.

Test results of `develop` after adding the new test:
```
1 failed, 1108 passed, 110 skipped, 28 xfailed, 406 warnings
```
Test results after fix:
```
1109 passed, 110 skipped, 28 xfailed, 406 warnings
```
(These tests were run with only NNEnum installed)