### PR TITLE
Fix library dependency finder

### DIFF
--- a/dnnv/_manage/linux/environment/dependencies/base.py
+++ b/dnnv/_manage/linux/environment/dependencies/base.py
@@ -75,23 +75,17 @@ class LibraryDependency(Dependency):
         if not self.allow_from_system:
             return None
         proc = sp.run(
-            shlex.split(f"ldconfig -p | grep /{self.name}.so$"),
+            shlex.split("ldconfig -p"),
             stdout=sp.PIPE,
             stderr=sp.STDOUT,
             encoding="utf8",
             env=envvars,
         )
-        if proc.returncode == 0:
-            return Path(proc.stdout.split("=>")[-1].strip())
-        proc = sp.run(
-            shlex.split(f"ldconfig -p | grep /{self.name}.a$"),
-            stdout=sp.PIPE,
-            stderr=sp.STDOUT,
-            encoding="utf8",
-            env=envvars,
-        )
-        if proc.returncode == 0:
-            return Path(proc.stdout.split("=>")[-1].strip())
+        if proc.returncode != 0:
+            return None
+        for line in proc.stdout.split("\n"):
+            if line.endswith(f"/{self.name}.so") or line.endswith(f"/{self.name}.a"):
+                return Path(line.split("=>")[-1].strip())
         return None
 
 

--- a/dnnv/_manage/linux/verifiers/mipverify.py
+++ b/dnnv/_manage/linux/verifiers/mipverify.py
@@ -97,7 +97,9 @@ class JuliaInstaller(Installer):
 
 def install(env: Environment):
     zlib_installer = GNUInstaller(
-        "zlib", "1.2.11", "https://www.zlib.net/zlib-1.2.11.tar.xz"
+        "zlib",
+        "1.2.12",
+        "https://github.com/madler/zlib/archive/refs/tags/v1.2.12.tar.gz",
     )
     gurobi_installer = GurobiInstaller("9.1.2")
     env.ensure_dependencies(

--- a/dnnv/_manage/linux/verifiers/planet.py
+++ b/dnnv/_manage/linux/verifiers/planet.py
@@ -58,7 +58,9 @@ def install(env: Environment):
         "gmp", "6.1.2", "https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz"
     )
     zlib_installer = GNUInstaller(
-        "zlib", "1.2.11", "https://www.zlib.net/zlib-1.2.11.tar.xz"
+        "zlib",
+        "1.2.12",
+        "https://github.com/madler/zlib/archive/refs/tags/v1.2.12.tar.gz",
     )
     glpk_installer = GNUInstaller("glpk", "4.65")
     valgrind_installer = GNUInstaller(


### PR DESCRIPTION
Was using a unix pipe in a subprocess command, which doesn't work. Modified the library search to be done in python rather than piping to grep.

Also updated the url for zlib to something a bit more robust (hopefully), which was the original symptom for this bug.