### PR TITLE
feature: simplifier to transform maxpool into conv and relu operations

### DIFF
--- a/dnnv/nn/transformers/simplifiers/__init__.py
+++ b/dnnv/nn/transformers/simplifiers/__init__.py
@@ -1,16 +1,71 @@
-from .base import *
-from .bundle_padding import *
-from .bundle_transpose import *
-from .convert_add import *
-from .convert_batch_norm import *
-from .convert_div_to_mul import *
-from .convert_matmul_to_gemm import *
-from .convert_mul import *
-from .convert_reshape_to_flatten import *
-from .convert_sub_to_add import *
-from .drop_identities import *
-from .move_activations_back import *
-from .squeeze_convs import *
-from .squeeze_gemms import *
+import logging
+import os
+import typing
 
-__all__ = ["simplify"]
+from ....errors import DNNVError
+from ...graph import OperationGraph
+from .base import ComposeSimplifiers, Simplifier
+from .bundle_padding import BundlePadding
+from .bundle_transpose import BundleTranspose
+from .convert_add import ConvertAdd
+from .convert_batch_norm import ConvertBatchNorm
+from .convert_div_to_mul import ConvertDivToMul
+from .convert_matmul_to_gemm import ConvertMatMulToGemm
+from .convert_mul import ConvertMul
+from .convert_reshape_to_flatten import ConvertReshapeToFlatten
+from .convert_sub_to_add import ConvertSubToAdd
+from .drop_identities import (
+    DropIdentity,
+    DropUnncessaryRelu,
+    DropUnnecessaryConcat,
+    DropUnnecessaryFlatten,
+)
+from .move_activations_back import MoveActivationsBackward
+from .reluify_maxpool import ReluifyMaxPool
+from .squeeze_convs import SqueezeConvs
+from .squeeze_gemms import SqueezeGemms
+
+DEFAULT_SIMPLIFIERS = [
+    BundlePadding,
+    BundleTranspose,
+    ConvertAdd,
+    ConvertBatchNorm,
+    ConvertDivToMul,
+    ConvertMatMulToGemm,
+    ConvertMul,
+    ConvertReshapeToFlatten,
+    ConvertSubToAdd,
+    DropIdentity,
+    DropUnnecessaryConcat,
+    DropUnnecessaryFlatten,
+    DropUnncessaryRelu,
+    MoveActivationsBackward,
+    SqueezeConvs,
+    SqueezeGemms,
+]
+
+OPTIONAL_SIMPLIFIERS: typing.Dict[str, typing.Type[Simplifier]] = {
+    simplifier_type.__name__: simplifier_type for simplifier_type in (ReluifyMaxPool,)
+}
+
+
+def simplify(
+    dnn: OperationGraph, simplifier: typing.Optional[Simplifier] = None
+) -> OperationGraph:
+    logger = logging.getLogger(__name__)
+    if simplifier is None:
+        simplifiers = list(DEFAULT_SIMPLIFIERS)
+        optional_simplifiers = os.getenv("DNNV_OPTIONAL_SIMPLIFIERS")
+        if optional_simplifiers:
+            for name in optional_simplifiers.split(":"):
+                logger.log(logging.WARNING, "Using optional simplifier: %s", name)
+                try:
+                    simplifiers.append(OPTIONAL_SIMPLIFIERS[name])
+                except KeyError:
+                    raise DNNVError(f"Unknown simplifier: {name}")
+        simplifier = ComposeSimplifiers(dnn, *simplifiers)
+    simplified_graph = OperationGraph(dnn.walk(simplifier))
+    return simplified_graph
+
+
+__all__ = ["simplify", "Simplifier", "ComposeSimplifiers"]

--- a/dnnv/nn/transformers/simplifiers/base.py
+++ b/dnnv/nn/transformers/simplifiers/base.py
@@ -1,6 +1,5 @@
-from typing import Dict, Optional, Type
+from typing import Dict, Type
 
-from ....utils import get_subclasses
 from ...analyzers import Analysis
 from ...graph import OperationGraph
 from ...operations import Operation
@@ -53,15 +52,4 @@ class ComposeSimplifiers(Simplifier):
         return operation
 
 
-def simplify(
-    dnn: OperationGraph, simplifier: Optional[Simplifier] = None
-) -> OperationGraph:
-    if simplifier is None:
-        simplifier = ComposeSimplifiers(
-            dnn, *[c for c in get_subclasses(Simplifier) if not c is ComposeSimplifiers]
-        )
-    simplified_graph = OperationGraph(dnn.walk(simplifier))
-    return simplified_graph
-
-
-__all__ = ["simplify", "Simplifier", "ComposeSimplifiers"]
+__all__ = ["Simplifier", "ComposeSimplifiers"]

--- a/dnnv/nn/transformers/simplifiers/bundle_padding.py
+++ b/dnnv/nn/transformers/simplifiers/bundle_padding.py
@@ -11,10 +11,17 @@ class BundlePadding(Simplifier):
         input_op = operation.x
         if not isinstance(input_op, operations.Pad):
             return operation
+        if all(p == 0 for p in input_op.pads):
+            operation = copy(operation)
+            operation.x = input_op.x
+            return operation
         pads = operation.pads
         if input_op.mode != "constant" or input_op.value != 0.0:
             return operation
-        if not all(p == 0 for p in input_op.pads[:4]):
+        num_pads = len(input_op.pads)
+        if any(p != 0 for p in input_op.pads[:2]) or any(
+            p != 0 for p in input_op.pads[num_pads // 2 : num_pads // 2 + 2]
+        ):
             return operation
         operation = copy(operation)
         pad_top, pad_left = input_op.pads[2:4]
@@ -27,14 +34,24 @@ class BundlePadding(Simplifier):
         input_op = operation.x
         if not isinstance(input_op, operations.Pad):
             return operation
+        if all(p == 0 for p in input_op.pads):
+            operation = copy(operation)
+            operation.x = input_op.x
+            return operation
+        num_pads = len(input_op.pads)
+        if any(p != 0 for p in input_op.pads[:2]) or any(
+            p != 0 for p in input_op.pads[num_pads // 2 : num_pads // 2 + 2]
+        ):
+            return operation
+        if input_op.mode != "constant" or not np.isnan(input_op.value):
+            return operation
         pads = operation.pads
-        if input_op.mode != "constant" or input_op.value != 0.0:
-            return operation
-        if not all(p == 0 for p in input_op.pads[:4]):
-            return operation
         operation = copy(operation)
         pad_top, pad_left = input_op.pads[2:4]
         pad_bottom, pad_right = input_op.pads[6:8]
         operation.pads = pads + np.array([pad_top, pad_left, pad_bottom, pad_right])
         operation.x = input_op.x
         return operation
+
+
+__all__ = ["BundlePadding"]

--- a/dnnv/nn/transformers/simplifiers/bundle_transpose.py
+++ b/dnnv/nn/transformers/simplifiers/bundle_transpose.py
@@ -59,3 +59,6 @@ class BundleTranspose(Simplifier):
         operation.b = b[weights_permutation]
         operation.transpose_b = False
         return operation
+
+
+__all__ = ["BundleTranspose"]

--- a/dnnv/nn/transformers/simplifiers/convert_add.py
+++ b/dnnv/nn/transformers/simplifiers/convert_add.py
@@ -9,7 +9,6 @@ class ConvertAdd(Simplifier):
     def visit_Add(self, operation: operations.Add) -> operations.Operation:
         a = operation.a
         b = operation.b
-        transpose_a = False
         if isinstance(a, operations.Operation) and isinstance(b, operations.Operation):
             return operation
         elif isinstance(a, operations.Operation):
@@ -20,7 +19,6 @@ class ConvertAdd(Simplifier):
         elif isinstance(b, operations.Operation):
             input_op = b
             c = a
-            transpose_a = True
             if np.all(c == 0):
                 return input_op
         else:
@@ -33,12 +31,12 @@ class ConvertAdd(Simplifier):
         elif len(input_shape) == 1:
             return operation
         elif len(input_shape) == 2:
-            w = np.eye(input_shape[1 - transpose_a], dtype=input_dtype)
+            w = np.eye(input_shape[1], dtype=input_dtype)
         elif len(input_shape) == 4:
             return operation
         else:
             return operation
-        return operations.Gemm(input_op, w, c, transpose_a=transpose_a)
+        return operations.Gemm(input_op, w, c)
 
 
 __all__ = ["ConvertAdd"]

--- a/dnnv/nn/transformers/simplifiers/convert_batch_norm.py
+++ b/dnnv/nn/transformers/simplifiers/convert_batch_norm.py
@@ -51,14 +51,16 @@ class ConvertBatchNorm(Simplifier):
             elif len(input_shape) == 4:
                 c = operation.mean.shape[0]
                 std = np.sqrt(operation.variance + operation.epsilon)
-                k = np.zeros(
+                W = np.zeros(
                     (c, c, 1, 1), dtype=input_dtype
                 )  # identity kernel (H, W, inC, outC)
                 for i in range(c):
-                    k[i, i, 0, 0] = 1
-                W = k * operation.scale / std
+                    W[i, i, 0, 0] = operation.scale[i] / std[i]
                 b = operation.bias - operation.scale * operation.mean / std
                 op = operations.Conv(input_op, W, b)
                 return op
         # TODO : in what other scenarios can BatchNorm be converted?
         return operation
+
+
+__all__ = ["ConvertBatchNorm"]

--- a/dnnv/nn/transformers/simplifiers/convert_div_to_mul.py
+++ b/dnnv/nn/transformers/simplifiers/convert_div_to_mul.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import numpy as np
 
 from ... import operations
@@ -21,10 +19,6 @@ class ConvertDivToMul(Simplifier):
             c = operation.a
             if np.all(c == 0):
                 return c
-            return operation
-        else:
-            return operation
-        if isinstance(input_op, operations.Add):
             return operation
         # TODO : this loses a lot of precision, so don't do it
         # return operations.Mul(input_op, 1.0 / c)

--- a/dnnv/nn/transformers/simplifiers/convert_mul.py
+++ b/dnnv/nn/transformers/simplifiers/convert_mul.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import numpy as np
 
 from ... import operations
@@ -46,20 +44,6 @@ class ConvertMul(Simplifier):
             if np.size(c) > input_shape[-1]:
                 return operation
             w = np.diag(np.reshape(c, -1))
-        elif len(input_shape) == 4:
-            num_channels = input_shape[1]
-            if not np.size(c) == num_channels:
-                return operation
-            w = np.diag(np.reshape(c, -1)).reshape(num_channels, num_channels, 1, 1)
-            c = np.reshape(c, -1)
-            return operations.Conv(
-                input_op,
-                w,
-                c,
-                kernel_shape=np.array([num_channels, num_channels]),
-                pads=np.array([0, 0, 0, 0]),
-                strides=np.array([1, 1]),
-            )
         else:
             return operation
         return operations.Add(operations.MatMul(input_op, w), b)

--- a/dnnv/nn/transformers/simplifiers/convert_reshape_to_flatten.py
+++ b/dnnv/nn/transformers/simplifiers/convert_reshape_to_flatten.py
@@ -25,3 +25,6 @@ class ConvertReshapeToFlatten(Simplifier):
             return operation
         shape: operations.Shape = gather.x
         return operations.Flatten(shape.x, axis=1)
+
+
+__all__ = ["ConvertReshapeToFlatten"]

--- a/dnnv/nn/transformers/simplifiers/drop_identities.py
+++ b/dnnv/nn/transformers/simplifiers/drop_identities.py
@@ -23,3 +23,21 @@ class DropUnnecessaryFlatten(Simplifier):
         ):
             return operation.x
         return operation
+
+
+class DropUnncessaryRelu(Simplifier):
+    def visit_Relu(self, operation: operations.Relu):
+        input_op = operation.x
+        if isinstance(
+            input_op, (operations.Relu, operations.Sigmoid, operations.Softmax)
+        ):
+            return input_op
+        return operation
+
+
+__all__ = [
+    "DropIdentity",
+    "DropUnnecessaryConcat",
+    "DropUnnecessaryFlatten",
+    "DropUnncessaryRelu",
+]

--- a/dnnv/nn/transformers/simplifiers/move_activations_back.py
+++ b/dnnv/nn/transformers/simplifiers/move_activations_back.py
@@ -29,4 +29,4 @@ class MoveActivationsBackward(Simplifier):
         return self.move_back(operation)
 
 
-__all__ = MoveActivationsBackward
+__all__ = ["MoveActivationsBackward"]

--- a/dnnv/nn/transformers/simplifiers/move_activations_back.py
+++ b/dnnv/nn/transformers/simplifiers/move_activations_back.py
@@ -27,3 +27,6 @@ class MoveActivationsBackward(Simplifier):
 
     def visit_Sigmoid(self, operation: operations.Sigmoid):
         return self.move_back(operation)
+
+
+__all__ = MoveActivationsBackward

--- a/dnnv/nn/transformers/simplifiers/reluify_maxpool.py
+++ b/dnnv/nn/transformers/simplifiers/reluify_maxpool.py
@@ -1,0 +1,130 @@
+from copy import copy
+from typing import List, Union
+
+import numpy as np
+
+from ... import OperationGraph, operations
+from .base import Simplifier
+
+
+class ReluifyMaxPool(Simplifier):
+    @staticmethod
+    def reluify_maxpool(
+        operation: operations.MaxPool,
+    ) -> Union[operations.Relu, operations.MaxPool]:
+        if operation.ceil_mode:
+            # TODO : can we support this?
+            return operation
+        if np.any(operation.dilations != 1):
+            # TODO : can we support this?
+            return operation
+        input_op = operation.x
+        kernel_shape = operation.kernel_shape
+        k = int(np.product(kernel_shape))
+        if k == 1:
+            return operation
+
+        (_, num_channels, *_), dtype = OperationGraph([input_op]).output_details[0]
+        num_comparisons = int(np.ceil(k / 2))
+        w = np.zeros((num_channels * num_comparisons * 3, num_channels, k), dtype=dtype)
+        for channel_i in range(num_channels):
+            for cmp_i in range(num_comparisons):
+                index = np.ravel_multi_index(
+                    (channel_i, cmp_i, 0), (num_channels, num_comparisons, 3)
+                )
+                idx1 = 2 * cmp_i
+                idx2 = 2 * cmp_i + 1
+                if idx2 < k:
+                    w[index + 0, channel_i, idx1] = 1
+                    w[index + 0, channel_i, idx2] = -1
+                    w[index + 1, channel_i, idx2] = 1
+                    w[index + 2, channel_i, idx2] = -1
+                else:
+                    w[index + 1, channel_i, idx1] = 1
+                    w[index + 2, channel_i, idx1] = -1
+        w = w.reshape(num_channels * num_comparisons * 3, num_channels, *kernel_shape)
+        initial_conv = operations.Conv(
+            input_op, w, strides=operation.strides, pads=operation.pads
+        )
+        initial_relu = operations.Relu(initial_conv)
+
+        new_ops: List[Union[operations.Conv, operations.Relu]] = [initial_relu]
+        while num_comparisons != 1:
+            num_values = num_comparisons
+            num_comparisons = int(np.ceil(num_values / 2))
+            w = np.zeros(
+                (
+                    num_channels * num_comparisons * 3,
+                    num_channels * num_values * 3,
+                    1,
+                    1,
+                ),
+                dtype=dtype,
+            )
+            for channel_i in range(num_channels):
+                for cmp_i in range(num_comparisons):
+                    index = np.ravel_multi_index(
+                        (channel_i, cmp_i, 0), (num_channels, num_comparisons, 3)
+                    )
+                    idx1 = int(
+                        np.ravel_multi_index(
+                            (channel_i, 2 * cmp_i, 0), (num_channels, num_values, 3)
+                        )
+                    )
+                    if 2 * cmp_i + 1 < num_values:
+                        idx2 = int(
+                            np.ravel_multi_index(
+                                (channel_i, 2 * cmp_i + 1, 0),
+                                (num_channels, num_values, 3),
+                            )
+                        )
+                        w[index + 0, idx1 + 0, 0, 0] = 1
+                        w[index + 0, idx1 + 1, 0, 0] = 1
+                        w[index + 0, idx1 + 2, 0, 0] = -1
+
+                        w[index + 0, idx2 + 0, 0, 0] = -1
+                        w[index + 0, idx2 + 1, 0, 0] = -1
+                        w[index + 0, idx2 + 2, 0, 0] = 1
+
+                        w[index + 1, idx2 + 0, 0, 0] = 1
+                        w[index + 1, idx2 + 1, 0, 0] = 1
+                        w[index + 1, idx2 + 2, 0, 0] = -1
+
+                        w[index + 2, idx2 + 0, 0, 0] = -1
+                        w[index + 2, idx2 + 1, 0, 0] = -1
+                        w[index + 2, idx2 + 2, 0, 0] = 1
+                    else:
+                        w[index + 1, idx1 + 0, 0, 0] = 1
+                        w[index + 1, idx1 + 1, 0, 0] = 1
+                        w[index + 1, idx1 + 2, 0, 0] = -1
+
+                        w[index + 2, idx1 + 0, 0, 0] = -1
+                        w[index + 2, idx1 + 1, 0, 0] = -1
+                        w[index + 2, idx1 + 2, 0, 0] = 1
+            new_ops.append(operations.Conv(new_ops[-1], w))
+            new_ops.append(operations.Relu(new_ops[-1]))
+
+        w = np.zeros((num_channels, num_channels * 3, 1, 1), dtype=dtype)
+        for channel_i in range(num_channels):
+            index = np.ravel_multi_index((channel_i, 0, 0), (num_channels, 1, 3))
+            w[channel_i, index + 0, 0, 0] = 1
+            w[channel_i, index + 1, 0, 0] = 1
+            w[channel_i, index + 2, 0, 0] = -1
+        new_ops.append(operations.Conv(new_ops[-1], w))
+
+        new_op = operations.Relu(new_ops[-1])
+        return new_op
+
+    def visit_MaxPool(
+        self, operation: operations.MaxPool
+    ) -> Union[operations.Relu, operations.MaxPool]:
+        if not isinstance(operation.x, operations.Relu):
+            return operation
+        return self.reluify_maxpool(operation)
+
+    def visit_Relu(
+        self, operation: operations.Relu
+    ) -> Union[operations.Relu, operations.MaxPool]:
+        if not isinstance(operation.x, operations.MaxPool):
+            return operation
+        return self.reluify_maxpool(operation.x)

--- a/dnnv/nn/transformers/simplifiers/reluify_maxpool.py
+++ b/dnnv/nn/transformers/simplifiers/reluify_maxpool.py
@@ -1,4 +1,3 @@
-from copy import copy
 from typing import List, Union
 
 import numpy as np
@@ -128,3 +127,6 @@ class ReluifyMaxPool(Simplifier):
         if not isinstance(operation.x, operations.MaxPool):
             return operation
         return self.reluify_maxpool(operation.x)
+
+
+__all__ = ["ReluifyMaxPool"]

--- a/dnnv/nn/transformers/simplifiers/squeeze_convs.py
+++ b/dnnv/nn/transformers/simplifiers/squeeze_convs.py
@@ -40,3 +40,6 @@ class SqueezeConvs(Simplifier):
 
             return op
         return operation
+
+
+__all__ = ["SqueezeConvs"]

--- a/dnnv/nn/transformers/simplifiers/squeeze_gemms.py
+++ b/dnnv/nn/transformers/simplifiers/squeeze_gemms.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from ... import operations
@@ -38,33 +40,46 @@ class SqueezeGemms(Simplifier):
         elif isinstance(operation.b, operations.Gemm):
             # TODO : reduce when operation.b is Gemm
             return operation
-        elif isinstance(operation.a, operations.Flatten) and isinstance(
-            operation.a.x, operations.Conv
+        elif (
+            isinstance(operation.a, operations.Flatten)
+            and operation.a.axis == 1
+            and isinstance(operation.a.x, operations.Conv)
         ):
             if operation.transpose_a:
                 return operation
             flatten_op = operation.a
             conv_op = flatten_op.x
-            if conv_op.w.shape[0] != conv_op.w.shape[1]:
-                return operation
-            if conv_op.w.shape[2] != conv_op.w.shape[3] and conv_op.shape[2] != 1:
+            conv_op_graph = OperationGraph([conv_op])
+            conv_output_shape = conv_op_graph.output_shape[0]
+            conv_input_shape = conv_op_graph.input_shape[0]
+            dtype = operation.b.dtype
+            if conv_output_shape[1:] != conv_input_shape[1:]:
                 # TODO : handle this case
                 return operation
-            input_shape = OperationGraph([conv_op]).output_shape[0]
-            flat_input_shape = np.product(input_shape[1:])
-            W = np.zeros((flat_input_shape, flat_input_shape)).astype(operation.b.dtype)
-            for (b, i, h, w) in np.ndindex(input_shape):
-                for j in range(input_shape[1]):
-                    k = np.ravel_multi_index((b, i, h, w), input_shape)
-                    l = np.ravel_multi_index((b, j, h, w), input_shape)
-                    W[k, l] = conv_op.w[i, j, 0, 0]
-            op_b = operation.b
-            if operation.transpose_b:
-                op_b = op_b.T
+            flat_shape = np.product(conv_output_shape[1:])
+            W = np.zeros((flat_shape, flat_shape), dtype=dtype)
+            for (b, i, h, w) in np.ndindex(*conv_output_shape):
+                for j in range(conv_output_shape[1]):
+                    k = np.ravel_multi_index((b, i, h, w), conv_output_shape)
+                    l = np.ravel_multi_index((b, j, h, w), conv_output_shape)
+                    W[l, k] = conv_op.w[i, j, 0, 0]
+            op_b = operation.b.T if operation.transpose_b else operation.b
             W = W @ op_b
-            bias = np.tile(conv_op.b, np.product(input_shape[2:]))
-            bias = bias @ op_b + operation.c
+            bias: Optional[np.ndarray] = np.array(0, dtype=dtype)
+            if conv_op.b is None and operation.c is None:
+                bias = None
+            if conv_op.b is not None:
+                bias = np.zeros(flat_shape, dtype=dtype)
+                for (b, i, h, w) in np.ndindex(*conv_output_shape):
+                    k = np.ravel_multi_index((b, i, h, w), conv_output_shape)
+                    bias[k] = conv_op.b[i]
+                bias = bias @ op_b
+            if operation.c is not None:
+                bias = bias + operation.c
             new_flatten_op = operations.Flatten(conv_op.x, axis=flatten_op.axis)
             gemm_op = operations.Gemm(new_flatten_op, W, bias)
             return gemm_op
         return operation
+
+
+__all__ = ["SqueezeGemms"]

--- a/dnnv/nn/visitors.py
+++ b/dnnv/nn/visitors.py
@@ -103,7 +103,6 @@ class PrintVisitor(OperationVisitor):
 
     def print_op_id(self, operation: Operation) -> None:
         op_id = self.get_op_id(operation)
-        # print("%-32s" % op_id, end=": ")
         print(f"{op_id:32s}", end=": ")
 
     def visit_Add(self, operation: operations.Add) -> None:

--- a/dnnv/properties/transformers/substitute_calls/_calls/max.py
+++ b/dnnv/properties/transformers/substitute_calls/_calls/max.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
 import numpy as np
-
 from numpy._globals import _NoValue
 
+from ....expressions import And, CallableExpression, Constant, Expression, IfThenElse
 from .base import FunctionSubstitutor
 from .utils import FunctionSubstitutionError, get_parameters
-from ....expressions import (
-    And,
-    CallableExpression,
-    Constant,
-    Expression,
-    IfThenElse,
-)
 
 
 class BuiltinMax(FunctionSubstitutor):

--- a/dnnv/properties/transformers/substitute_calls/_calls/mean.py
+++ b/dnnv/properties/transformers/substitute_calls/_calls/mean.py
@@ -2,14 +2,9 @@ from __future__ import annotations
 
 import numpy as np
 
+from ....expressions import Add, CallableExpression, Constant, Expression
 from .base import FunctionSubstitutor
 from .utils import get_parameters
-from ....expressions import (
-    Add,
-    CallableExpression,
-    Constant,
-    Expression,
-)
 
 
 class NumpyMean(FunctionSubstitutor):

--- a/dnnv/properties/transformers/substitute_calls/_calls/min.py
+++ b/dnnv/properties/transformers/substitute_calls/_calls/min.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
 import numpy as np
-
 from numpy._globals import _NoValue
 
+from ....expressions import And, CallableExpression, Constant, Expression, IfThenElse
 from .base import FunctionSubstitutor
 from .utils import FunctionSubstitutionError, get_parameters
-from ....expressions import (
-    And,
-    CallableExpression,
-    Constant,
-    Expression,
-    IfThenElse,
-)
 
 
 class BuiltinMin(FunctionSubstitutor):

--- a/dnnv/properties/transformers/substitute_calls/_calls/shape.py
+++ b/dnnv/properties/transformers/substitute_calls/_calls/shape.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 
+from .... import Expression, expressions
 from .base import FunctionSubstitutor
-from .... import expressions, Expression
 
 
 class Shape(FunctionSubstitutor):

--- a/dnnv/properties/transformers/substitute_calls/_calls/sum.py
+++ b/dnnv/properties/transformers/substitute_calls/_calls/sum.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
 import inspect
-import numpy as np
 
+import numpy as np
 from numpy._globals import _NoValue
 
+from ....expressions import Add, CallableExpression, Constant, Expression
 from .base import FunctionSubstitutor
 from .utils import get_parameters
-from ....expressions import (
-    Add,
-    CallableExpression,
-    Constant,
-    Expression,
-)
 
 
 class BuiltinSum(FunctionSubstitutor):

--- a/dnnv/properties/transformers/substitute_calls/_calls/utils.py
+++ b/dnnv/properties/transformers/substitute_calls/_calls/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-
 from typing import Any, Collection, Dict
 
 from ...errors import ExpressionTransformerError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ readme = "README.md"
 license = { file = "LICENSE" }
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.7"
-dynamic = ["version", 'description']
+version = "0.5.1"
+dynamic = ["description"]
 keywords = ["DNN", "neural network", "verification"]
 dependencies = [
     "lark~=1.0",

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_bundle_padding.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_bundle_padding.py
@@ -1,0 +1,144 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.bundle_padding import BundlePadding
+from dnnv.nn.visitors import EnsureSupportVisitor, OperationCounter
+
+
+def test_bundle_padding_conv():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 0, 2, 2, 0, 0, 2, 2))
+    conv_op = operations.Conv(
+        pad_op, np.random.randn(5, 3, 2, 2).astype(input_op.dtype)
+    )
+    op_graph = OperationGraph([conv_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 3
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_bundle_padding_conv_nopad():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 0, 0, 0, 0, 0, 0, 0))
+    conv_op = operations.Conv(
+        pad_op, np.random.randn(5, 3, 2, 2).astype(input_op.dtype)
+    )
+    op_graph = OperationGraph([conv_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 3
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_bundle_padding_conv_noop():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 1, 2, 2, 0, 1, 2, 2))
+    conv_op = operations.Conv(
+        pad_op, np.random.randn(5, 3, 2, 2).astype(input_op.dtype)
+    )
+    # testing weird padding
+    op_graph = OperationGraph([conv_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]
+
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 0, 2, 2, 0, 0, 2, 2), mode="reflect")
+    conv_op = operations.Conv(
+        pad_op, np.random.randn(5, 3, 2, 2).astype(input_op.dtype)
+    )
+    # testing non-constant padding
+    op_graph = OperationGraph([conv_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]
+
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 0, 2, 2, 0, 0, 2, 2), value=5)
+    conv_op = operations.Conv(
+        pad_op, np.random.randn(5, 3, 2, 2).astype(input_op.dtype)
+    )
+    # testing non-zero constant padding
+    op_graph = OperationGraph([conv_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]
+
+
+def test_bundle_padding_maxpool():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 0, 2, 2, 0, 0, 2, 2), value=np.nan)
+    maxpool_op = operations.MaxPool(pad_op, (2, 2))
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.MaxPool])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 3
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_bundle_padding_maxpool_nopad():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 0, 0, 0, 0, 0, 0, 0))
+    maxpool_op = operations.MaxPool(pad_op, (2, 2))
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.MaxPool])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 3
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_bundle_padding_maxpool_noop():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 1, 2, 2, 0, 1, 2, 2))
+    maxpool_op = operations.MaxPool(pad_op, (2, 2))
+    # testing weird padding
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]
+
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 0, 2, 2, 0, 0, 2, 2), mode="reflect")
+    maxpool_op = operations.MaxPool(pad_op, (2, 2))
+    # testing non-constant padding
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]
+
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    pad_op = operations.Pad(input_op, (0, 0, 2, 2, 0, 0, 2, 2), value=5)
+    maxpool_op = operations.MaxPool(pad_op, (2, 2))
+    # testing non-nan constant padding
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, BundlePadding(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_add.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_add.py
@@ -1,0 +1,79 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.convert_add import ConvertAdd
+from dnnv.nn.visitors import EnsureSupportVisitor
+
+
+def test_convert_add():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    add_op = operations.Add(
+        input_op, np.random.randn(1, *input_op.shape[1:]).astype(input_op.dtype)
+    )
+    op_graph = OperationGraph([add_op])
+    simplified_op_graph = simplify(op_graph, ConvertAdd(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    add_op = operations.Add(
+        np.random.randn(1, *input_op.shape[1:]).astype(input_op.dtype), input_op
+    )
+    op_graph = OperationGraph([add_op])
+    simplified_op_graph = simplify(op_graph, ConvertAdd(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_convert_add_zero():
+    input_op = operations.Input((-1, 3, 4, 5), dtype=np.dtype(np.float64))
+    add_op = operations.Add(
+        input_op, np.zeros((1, *input_op.shape[1:]), dtype=input_op.dtype)
+    )
+    op_graph = OperationGraph([add_op])
+    simplified_op_graph = simplify(op_graph, ConvertAdd(op_graph))
+
+    assert simplified_op_graph.walk(EnsureSupportVisitor([operations.Input]))
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    add_op = operations.Add(
+        np.zeros((1, *input_op.shape[1:]), dtype=input_op.dtype), input_op
+    )
+    op_graph = OperationGraph([add_op])
+    simplified_op_graph = simplify(op_graph, ConvertAdd(op_graph))
+
+    assert simplified_op_graph.walk(EnsureSupportVisitor([operations.Input]))
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_convert_add_constants():
+    shape = (1, 5)
+    dtype = np.float64
+    add_op = operations.Add(
+        np.random.randn(*shape).astype(dtype), np.random.randn(*shape).astype(dtype)
+    )
+    op_graph = OperationGraph([add_op])
+    simplified_op_graph = simplify(op_graph, ConvertAdd(op_graph))
+    assert isinstance(simplified_op_graph.output_operations[0], np.ndarray)

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_batch_norm.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_batch_norm.py
@@ -1,0 +1,106 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.convert_batch_norm import ConvertBatchNorm
+from dnnv.nn.visitors import EnsureSupportVisitor, OperationCounter
+
+
+def test_convert_batch_norm_on_input():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    bn_op = operations.BatchNormalization(
+        input_op,
+        np.random.randn(input_op.shape[1]).astype(input_op.dtype),
+        np.random.randn(input_op.shape[1]).astype(input_op.dtype),
+        np.random.randn(input_op.shape[1]).astype(input_op.dtype),
+        abs(np.random.randn(input_op.shape[1]).astype(input_op.dtype)),
+    )
+    op_graph = OperationGraph([bn_op])
+    simplified_op_graph = simplify(op_graph, ConvertBatchNorm(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 2
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    input_op = operations.Input((-1, 3, 5, 5), dtype=np.dtype(np.float64))
+    bn_op = operations.BatchNormalization(
+        input_op,
+        np.random.randn(input_op.shape[1]).astype(input_op.dtype),
+        np.random.randn(input_op.shape[1]).astype(input_op.dtype),
+        np.random.randn(input_op.shape[1]).astype(input_op.dtype),
+        abs(np.random.randn(input_op.shape[1]).astype(input_op.dtype)),
+    )
+    op_graph = OperationGraph([bn_op])
+    simplified_op_graph = simplify(op_graph, ConvertBatchNorm(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 2
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_convert_batch_norm_on_gemm():
+    bn_size = 10
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    gemm_op = operations.Gemm(
+        input_op,
+        np.random.randn(input_op.shape[1], bn_size).astype(input_op.dtype),
+    )
+    bn_op = operations.BatchNormalization(
+        gemm_op,
+        np.random.randn(bn_size).astype(input_op.dtype),
+        np.random.randn(bn_size).astype(input_op.dtype),
+        np.random.randn(bn_size).astype(input_op.dtype),
+        abs(np.random.randn(bn_size).astype(input_op.dtype)),
+    )
+    op_graph = OperationGraph([bn_op])
+    simplified_op_graph = simplify(op_graph, ConvertBatchNorm(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_convert_batch_norm_on_conv():
+    bn_size = 5
+    input_op = operations.Input((-1, 3, 5, 5), dtype=np.dtype(np.float64))
+    conv_op = operations.Conv(
+        input_op,
+        np.random.randn(bn_size, input_op.shape[1], 2, 2).astype(input_op.dtype),
+    )
+    bn_op = operations.BatchNormalization(
+        conv_op,
+        np.random.randn(bn_size).astype(input_op.dtype),
+        np.random.randn(bn_size).astype(input_op.dtype),
+        np.random.randn(bn_size).astype(input_op.dtype),
+        abs(np.random.randn(bn_size).astype(input_op.dtype)),
+    )
+    op_graph = OperationGraph([bn_op])
+    simplified_op_graph = simplify(op_graph, ConvertBatchNorm(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_div_to_mul.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_div_to_mul.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.convert_div_to_mul import ConvertDivToMul
+from dnnv.nn.visitors import EnsureSupportVisitor, OperationCounter
+
+
+def test_convert_div_by_ones():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    div_op = operations.Div(
+        input_op,
+        np.ones(*input_op.shape[1:], dtype=input_op.dtype),
+    )
+    op_graph = OperationGraph([div_op])
+    simplified_op_graph = simplify(op_graph, ConvertDivToMul(op_graph))
+
+    assert simplified_op_graph.walk(EnsureSupportVisitor([operations.Input]))
+    assert op_graph.walk(OperationCounter())[-1] == 2
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 1
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_convert_div_zero():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    div_op = operations.Div(
+        np.zeros(*input_op.shape[1:], dtype=input_op.dtype),
+        input_op,
+    )
+    op_graph = OperationGraph([div_op])
+    simplified_op_graph = simplify(op_graph, ConvertDivToMul(op_graph))
+    assert isinstance(simplified_op_graph.output_operations[0], np.ndarray)
+    x = np.random.randn(1, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph.output_operations[0]
+    assert np.allclose(y1, y2)

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_matmul_to_gemm.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_matmul_to_gemm.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.convert_matmul_to_gemm import ConvertMatMulToGemm
+from dnnv.nn.visitors import EnsureSupportVisitor, OperationCounter
+
+
+def test_convert_matmul():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    matmul_op = operations.MatMul(
+        input_op,
+        np.random.randn(input_op.shape[1], 10).astype(input_op.dtype),
+    )
+    op_graph = OperationGraph([matmul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMatMulToGemm(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 2
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    input_op = operations.Input((5, -1), dtype=np.dtype(np.float64))
+    matmul_op = operations.MatMul(
+        np.random.randn(10, input_op.shape[0]).astype(input_op.dtype),
+        input_op,
+    )
+    op_graph = OperationGraph([matmul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMatMulToGemm(op_graph))
+    simplified_op_graph.pprint()
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 2
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(*input_op.shape[:1], 100).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_mul.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_mul.py
@@ -1,0 +1,192 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.convert_mul import ConvertMul
+from dnnv.nn.visitors import EnsureSupportVisitor
+
+
+def test_convert_mul():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    mul_op = operations.Mul(
+        input_op, np.random.randn(1, *input_op.shape[1:]).astype(input_op.dtype)
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor(
+            [
+                operations.Input,
+                operations.Add,
+                operations.MatMul,
+                operations.Gemm,
+                operations.Conv,
+            ]
+        )
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    mul_op = operations.Mul(
+        np.random.randn(1, *input_op.shape[1:]).astype(input_op.dtype), input_op
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor(
+            [
+                operations.Input,
+                operations.Add,
+                operations.MatMul,
+                operations.Gemm,
+                operations.Conv,
+            ]
+        )
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_convert_mul_ones():
+    input_op = operations.Input((-1, 3, 4, 5), dtype=np.dtype(np.float64))
+    mul_op = operations.Mul(
+        input_op, np.ones((1, *input_op.shape[1:]), dtype=input_op.dtype)
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+
+    assert simplified_op_graph.walk(EnsureSupportVisitor([operations.Input]))
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    mul_op = operations.Mul(
+        np.ones((1, *input_op.shape[1:]), dtype=input_op.dtype), input_op
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+
+    assert simplified_op_graph.walk(EnsureSupportVisitor([operations.Input]))
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_convert_mul_zero():
+    input_op = operations.Input((-1, 3, 4, 5), dtype=np.dtype(np.float64))
+    mul_op = operations.Mul(
+        input_op, np.zeros((1, *input_op.shape[1:]), dtype=input_op.dtype)
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+    assert np.allclose(
+        simplified_op_graph.output_operations[0], np.zeros((1, *input_op.shape[1:]))
+    )
+
+    mul_op = operations.Mul(
+        np.zeros((1, *input_op.shape[1:]), dtype=input_op.dtype), input_op
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+    assert np.allclose(
+        simplified_op_graph.output_operations[0], np.zeros((1, *input_op.shape[1:]))
+    )
+
+
+def test_convert_mul_constants():
+    shape = (1, 5)
+    dtype = np.float64
+    mul_op = operations.Mul(
+        np.random.randn(*shape).astype(dtype), np.random.randn(*shape).astype(dtype)
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+    assert isinstance(simplified_op_graph.output_operations[0], np.ndarray)
+
+
+def test_convert_mul_1d():
+    input_op = operations.Input((5,), dtype=np.dtype(np.float64))
+    mul_op = operations.Mul(
+        input_op, np.random.randn(*input_op.shape).astype(input_op.dtype)
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor(
+            [
+                operations.Input,
+                operations.Add,
+                operations.MatMul,
+                operations.Gemm,
+                operations.Conv,
+            ]
+        )
+    )
+
+    x = np.random.randn(*input_op.shape).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    mul_op = operations.Mul(
+        np.random.randn(*input_op.shape).astype(input_op.dtype), input_op
+    )
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor(
+            [
+                operations.Input,
+                operations.Add,
+                operations.MatMul,
+                operations.Gemm,
+                operations.Conv,
+            ]
+        )
+    )
+
+    x = np.random.randn(*input_op.shape).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_convert_mul_noop():
+    input_op_1 = operations.Input((1,), dtype=np.dtype(np.float64))
+    input_op_2 = operations.Input((1,), dtype=np.dtype(np.float64))
+    mul_op = operations.Mul(input_op_1, input_op_2)
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]
+
+    input_op = operations.Input((1,), dtype=np.dtype(np.float64))
+    mul_op = operations.Mul(input_op, np.random.randn(5).astype(input_op.dtype))
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]
+
+    input_op = operations.Input((), dtype=np.dtype(np.float64))
+    mul_op = operations.Mul(input_op, np.random.randn())
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]
+
+    input_op = operations.Input((1, 3, 4, 5), dtype=np.dtype(np.float64))
+    mul_op = operations.Mul(input_op, np.random.randn())
+    op_graph = OperationGraph([mul_op])
+    simplified_op_graph = simplify(op_graph, ConvertMul(op_graph))
+    assert simplified_op_graph.output_operations[0] == op_graph.output_operations[0]

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_drop_identities.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_drop_identities.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.drop_identities import (
+    DropIdentity,
+    DropUnncessaryRelu,
+    DropUnnecessaryConcat,
+    DropUnnecessaryFlatten,
+)
+from dnnv.nn.visitors import EnsureSupportVisitor, OperationCounter
+
+
+def test_drop_identity():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    identity_op = operations.Identity(input_op)
+    op_graph = OperationGraph([identity_op])
+    simplified_op_graph = simplify(op_graph, DropIdentity(op_graph))
+
+    assert simplified_op_graph.walk(EnsureSupportVisitor([operations.Input]))
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_drop_unnecessary_concat():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    identity_op = operations.Concat([input_op], axis=1)
+    op_graph = OperationGraph([identity_op])
+    simplified_op_graph = simplify(op_graph, DropUnnecessaryConcat(op_graph))
+
+    assert simplified_op_graph.walk(EnsureSupportVisitor([operations.Input]))
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_drop_unnecessary_flatten():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    identity_op = operations.Flatten(input_op, axis=1)
+    op_graph = OperationGraph([identity_op])
+    simplified_op_graph = simplify(op_graph, DropUnnecessaryFlatten(op_graph))
+
+    assert simplified_op_graph.walk(EnsureSupportVisitor([operations.Input]))
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_drop_unnecessary_relu():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    relu_op = operations.Relu(input_op)
+    identity_op = operations.Relu(relu_op)
+    op_graph = OperationGraph([identity_op])
+    simplified_op_graph = simplify(op_graph, DropUnncessaryRelu(op_graph))
+
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    relu_op = operations.Sigmoid(input_op)
+    identity_op = operations.Relu(relu_op)
+    op_graph = OperationGraph([identity_op])
+    simplified_op_graph = simplify(op_graph, DropUnncessaryRelu(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Sigmoid])
+    )
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_reluify_maxpool.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_reluify_maxpool.py
@@ -1,0 +1,121 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.reluify_maxpool import ReluifyMaxPool
+from dnnv.nn.visitors import EnsureSupportVisitor
+
+
+def test_pairwise():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    relu_op = operations.Relu(input_op)
+    maxpool_op = operations.MaxPool(relu_op, np.array([1, 2]))
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, ReluifyMaxPool(op_graph))
+
+    # only conv and relus should be left after reluification
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv, operations.Relu])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    assert np.allclose(op_graph(x), simplified_op_graph(x))
+
+
+def test_multistep():
+    input_op = operations.Input((-1, 3, 2, 2), dtype=np.dtype(np.float64))
+    relu_op = operations.Relu(input_op)
+    maxpool_op = operations.MaxPool(relu_op, np.array([2, 2]))
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, ReluifyMaxPool(op_graph))
+
+    # only conv and relus should be left after reluification
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv, operations.Relu])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_large_strided():
+    input_op = operations.Input((-1, 3, 12, 12), dtype=np.dtype(np.float64))
+    relu_op = operations.Relu(input_op)
+    maxpool_op = operations.MaxPool(relu_op, np.array([3, 3]), strides=np.array([3, 3]))
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, ReluifyMaxPool(op_graph))
+
+    # only conv and relus should be left after reluification
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv, operations.Relu])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_large_padded():
+    input_op = operations.Input((-1, 3, 12, 12), dtype=np.dtype(np.float64))
+    relu_op = operations.Relu(input_op)
+    maxpool_op = operations.MaxPool(
+        relu_op, np.array([3, 3]), pads=np.array([1, 1, 1, 1])
+    )
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, ReluifyMaxPool(op_graph))
+
+    # only conv and relus should be left after reluification
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv, operations.Relu])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_large_padded_and_strided():
+    input_op = operations.Input((-1, 3, 24, 18), dtype=np.dtype(np.float64))
+    relu_op = operations.Relu(input_op)
+    maxpool_op = operations.MaxPool(
+        relu_op, np.array([3, 3]), strides=np.array([2, 2]), pads=np.array([1, 1, 1, 1])
+    )
+    op_graph = OperationGraph([maxpool_op])
+    simplified_op_graph = simplify(op_graph, ReluifyMaxPool(op_graph))
+
+    # only conv and relus should be left after reluification
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv, operations.Relu])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_large_padded_and_strided_relu_first():
+    input_op = operations.Input((-1, 3, 24, 18), dtype=np.dtype(np.float64))
+    maxpool_op = operations.MaxPool(
+        input_op,
+        np.array([3, 3]),
+        strides=np.array([2, 2]),
+        pads=np.array([1, 1, 1, 1]),
+    )
+    relu_op = operations.Relu(maxpool_op)
+    op_graph = OperationGraph([relu_op])
+    simplified_op_graph = simplify(op_graph, ReluifyMaxPool(op_graph))
+
+    # only conv and relus should be left after reluification
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Conv, operations.Relu])
+    )
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_squeeze_gemms.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_squeeze_gemms.py
@@ -1,0 +1,174 @@
+import numpy as np
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.nn.transformers.simplifiers import simplify
+from dnnv.nn.transformers.simplifiers.squeeze_gemms import SqueezeGemms
+from dnnv.nn.visitors import EnsureSupportVisitor, OperationCounter
+
+
+def test_squeeze_gemms_no_c():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    gemm_op_1 = operations.Gemm(
+        input_op, np.random.randn(input_op.shape[1], 10).astype(input_op.dtype)
+    )
+    gemm_op_2 = operations.Gemm(
+        gemm_op_1, np.random.randn(10, 10).astype(input_op.dtype)
+    )
+    op_graph = OperationGraph([gemm_op_2])
+    simplified_op_graph = simplify(op_graph, SqueezeGemms(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 3
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_squeeze_gemms_one_c():
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    gemm_op_1 = operations.Gemm(
+        input_op,
+        np.random.randn(input_op.shape[1], 10).astype(input_op.dtype),
+        np.random.randn(10).astype(input_op.dtype),
+    )
+    gemm_op_2 = operations.Gemm(
+        gemm_op_1, np.random.randn(10, 10).astype(input_op.dtype)
+    )
+    op_graph = OperationGraph([gemm_op_2])
+    simplified_op_graph = simplify(op_graph, SqueezeGemms(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 3
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    input_op = operations.Input((-1, 5), dtype=np.dtype(np.float64))
+    gemm_op_1 = operations.Gemm(
+        input_op, np.random.randn(input_op.shape[1], 10).astype(input_op.dtype)
+    )
+    gemm_op_2 = operations.Gemm(
+        gemm_op_1,
+        np.random.randn(10, 10).astype(input_op.dtype),
+        np.random.randn(10).astype(input_op.dtype),
+    )
+    op_graph = OperationGraph([gemm_op_2])
+    simplified_op_graph = simplify(op_graph, SqueezeGemms(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.Gemm])
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 3
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 2
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_squeeze_gemms_with_conv():
+    input_op = operations.Input((-1, 3, 4, 4), dtype=np.dtype(np.float64))
+    conv_op = operations.Conv(
+        input_op,
+        np.random.randn(3, 3, 1, 1).astype(input_op.dtype),
+    )
+    flatten_op = operations.Flatten(conv_op)
+    gemm_op = operations.Gemm(
+        flatten_op,
+        np.random.randn(np.product(input_op.shape[1:]), 10).astype(input_op.dtype),
+    )
+    op_graph = OperationGraph([gemm_op])
+    simplified_op_graph = simplify(op_graph, SqueezeGemms(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor(
+            [
+                operations.Input,
+                operations.Flatten,
+                operations.Gemm,
+            ]
+        )
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 4
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 3
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+
+def test_squeeze_gemms_with_conv_with_bias():
+    input_op = operations.Input((-1, 3, 4, 4), dtype=np.dtype(np.float64))
+    conv_op = operations.Conv(
+        input_op,
+        np.random.randn(3, 3, 1, 1).astype(input_op.dtype),
+    )
+    flatten_op = operations.Flatten(conv_op)
+    gemm_op = operations.Gemm(
+        flatten_op,
+        np.random.randn(np.product(input_op.shape[1:]), 10).astype(input_op.dtype),
+        np.random.randn(10).astype(input_op.dtype),
+    )
+    op_graph = OperationGraph([gemm_op])
+    simplified_op_graph = simplify(op_graph, SqueezeGemms(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor(
+            [
+                operations.Input,
+                operations.Flatten,
+                operations.Gemm,
+            ]
+        )
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 4
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 3
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)
+
+    input_op = operations.Input((-1, 3, 4, 4), dtype=np.dtype(np.float64))
+    conv_op = operations.Conv(
+        input_op,
+        np.random.randn(3, 3, 1, 1).astype(input_op.dtype),
+        np.random.randn(3).astype(input_op.dtype),
+    )
+    flatten_op = operations.Flatten(conv_op)
+    gemm_op = operations.Gemm(
+        flatten_op,
+        np.random.randn(np.product(input_op.shape[1:]), 10).astype(input_op.dtype),
+        np.random.randn(10).astype(input_op.dtype),
+    )
+    op_graph = OperationGraph([gemm_op])
+    simplified_op_graph = simplify(op_graph, SqueezeGemms(op_graph))
+
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor(
+            [
+                operations.Input,
+                operations.Flatten,
+                operations.Gemm,
+            ]
+        )
+    )
+    assert op_graph.walk(OperationCounter())[-1] == 4
+    assert simplified_op_graph.walk(OperationCounter())[-1] == 3
+
+    x = np.random.randn(100, *input_op.shape[1:]).astype(input_op.dtype)
+    y1 = op_graph(x)
+    y2 = simplified_op_graph(x)
+    assert np.allclose(y1, y2)

--- a/tests/unit_tests/test_properties/test_transformers/test_SubstituteCalls/test_max/test___call__.py
+++ b/tests/unit_tests/test_properties/test_transformers/test_SubstituteCalls/test_max/test___call__.py
@@ -1,6 +1,7 @@
+import re
+
 import numpy as np
 import pytest
-import re
 
 from dnnv.properties.expressions import *
 from dnnv.properties.transformers import SubstituteCalls

--- a/tests/unit_tests/test_properties/test_transformers/test_SubstituteCalls/test_min/test___call__.py
+++ b/tests/unit_tests/test_properties/test_transformers/test_SubstituteCalls/test_min/test___call__.py
@@ -1,6 +1,7 @@
+import re
+
 import numpy as np
 import pytest
-import re
 
 from dnnv.errors import DNNVError
 from dnnv.properties.expressions import *

--- a/tests/unit_tests/test_properties/test_transformers/test_SubstituteCalls/test_sum/test___call__.py
+++ b/tests/unit_tests/test_properties/test_transformers/test_SubstituteCalls/test_sum/test___call__.py
@@ -1,6 +1,7 @@
+import sys
+
 import numpy as np
 import pytest
-import sys
 
 from dnnv.properties.expressions import *
 from dnnv.properties.transformers import SubstituteCalls


### PR DESCRIPTION
This is to add an optional simplifier that transforms MaxPool operations into a sequence of Conv and Relu operations. In general, a single MaxPool layer will be transformed into `lg(n)` Conv+Relu layers, where `n` is the size of the pooling kernel.

This simplifier is currently optional, since many verifiers do support MaxPool operations and may be negatively affected by this transformation. To enable this simplifier, set the environment variable `DNNV_OPTIONAL_SIMPLIFIERS=ReluifyMaxPool`. Currently `ReluifyMaxPool` is the only available optional simplifier, but in general, this environment variable takes a colon separated list of optional simplifier names. We currently log a warning message when networks are simplified using optional transforms specified using this variable to try to warn users of potentially unintended use.

It also adds a DropUnnecessaryRelus simplifier which removes relu operations which occur after operations that are guaranteed to have positive values (e.g., Relu, Sigmoid, and Softmax operations).