### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/dnnv
+            ~/.cache/pip
+          key: dnnv-${{ runner.os }}-${{ matrix.python-version }}
+          restore-keys: |
+            dnnv-${{ runner.os }}-
+            dnnv-
+
       - name: Install DNNV
         run: |
           python -m venv .venv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,17 +27,42 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "test"
-  test:
-    # The type of runner that the job will run on
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install DNNV
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install --upgrade pip
+          pip install .[test]
+
+      - name: Run DNNV Unit Tests
+        run: |
+          export TF_CPP_MIN_LOG_LEVEL=3
+          . .venv/bin/activate
+          coverage run -m pytest tests/unit_tests
+          coverage combine
+          coverage xml
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v1
+  system-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    steps:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -59,8 +84,8 @@ jobs:
         run: |
           python -m venv .venv
           . .venv/bin/activate
-          pip install --upgrade pip flit
-          flit install
+          pip install --upgrade pip
+          pip install .[test]
 
       - name: "Install Verifier: Reluplex"
         run: |
@@ -97,16 +122,11 @@ jobs:
           . .venv/bin/activate
           dnnv_manage install nnenum
 
-      - name: Prepare Test Artifacts
-        run: |
-          . .venv/bin/activate
-          python tests/system_tests/artifacts/build_artifacts.py
-
       - name: Run DNNV Test Suite
         run: |
           export TF_CPP_MIN_LOG_LEVEL=3
           . .venv/bin/activate
-          coverage run
+          coverage run -m pytest tests/system_tests
           coverage combine
           coverage xml
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,12 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  unit-tests:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+        test-type: ["unit", "system"]
     steps:
       - uses: actions/checkout@v2
 
@@ -46,87 +47,54 @@ jobs:
           . .venv/bin/activate
           pip install --upgrade pip
           pip install .[test]
-
-      - name: Run DNNV Unit Tests
-        run: |
-          export TF_CPP_MIN_LOG_LEVEL=3
-          . .venv/bin/activate
-          coverage run -m pytest tests/unit_tests
-          coverage combine
-          coverage xml
-
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v1
-  system-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/dnnv
-            ~/.cache/pip
-          key: dnnv-${{ runner.os }}-${{ matrix.python-version }}
-          restore-keys: |
-            dnnv-${{ runner.os }}-
-            dnnv-
-
-      - name: Install DNNV
-        run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          pip install --upgrade pip
-          pip install .[test]
-
-      - name: "Install Verifier: Reluplex"
-        run: |
-          . .venv/bin/activate
-          dnnv_manage install reluplex
-
-      - name: "Install Verifier: Planet"
-        run: |
-          . .venv/bin/activate
-          dnnv_manage install planet
-
-      - name: "Install Verifier: Neurify"
-        run: |
-          . .venv/bin/activate
-          dnnv_manage install neurify
 
       - name: "Install Verifier: ERAN"
+        if: ${{ matrix.test-type  == 'system' }}
         run: |
           . .venv/bin/activate
           dnnv_manage install eran
 
       - name: "Install Verifier: Marabou"
+        if: ${{ matrix.test-type  == 'system' }}
         run: |
           . .venv/bin/activate
           dnnv_manage install marabou
 
       - name: "Install Verifier: MIPVerify"
+        if: ${{ matrix.test-type  == 'system' }}
         run: |
           . .venv/bin/activate
           dnnv_manage install mipverify
 
+      - name: "Install Verifier: Neurify"
+        if: ${{ matrix.test-type  == 'system' }}
+        run: |
+          . .venv/bin/activate
+          dnnv_manage install neurify
+
       - name: "Install Verifier: nnenum"
+        if: ${{ matrix.test-type  == 'system' }}
         run: |
           . .venv/bin/activate
           dnnv_manage install nnenum
 
-      - name: Run DNNV Test Suite
+      - name: "Install Verifier: Planet"
+        if: ${{ matrix.test-type  == 'system' }}
+        run: |
+          . .venv/bin/activate
+          dnnv_manage install planet
+
+      - name: "Install Verifier: Reluplex"
+        if: ${{ matrix.test-type  == 'system' }}
+        run: |
+          . .venv/bin/activate
+          dnnv_manage install reluplex
+
+      - name: Run DNNV Unit Tests
         run: |
           export TF_CPP_MIN_LOG_LEVEL=3
           . .venv/bin/activate
-          coverage run -m pytest tests/system_tests
+          coverage run -m pytest tests/${{ matrix.test-type }}_tests
           coverage combine
           coverage xml
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [main, develop]
     paths:
@@ -21,11 +17,8 @@ on:
       - "tests/**"
       - "pyproject.toml"
       - "requirements.txt"
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -34,14 +27,14 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
         test-type: ["unit", "system"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/dnnv
@@ -109,4 +102,4 @@ jobs:
           coverage xml
 
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3

--- a/dnnv/_manage/linux/verifiers/bab.py
+++ b/dnnv/_manage/linux/verifiers/bab.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
 
 class BaBInstaller(Installer):
     def run(self, env: Environment, dependency: Dependency):
-        commit_hash = "d0e20ee"
+        commit_hash = "d0e20eed8d395c723d7b2903746feb7d0ec7db1c"
 
         cache_dir = env.cache_dir / f"bab-{commit_hash}"
         cache_dir.mkdir(exist_ok=True, parents=True)

--- a/dnnv/_manage/linux/verifiers/eran.py
+++ b/dnnv/_manage/linux/verifiers/eran.py
@@ -133,8 +133,8 @@ class ELINAInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            "rm -rf ELINA",
-            "git clone https://github.com/eth-sri/ELINA.git",
+            "if [ ! -e ELINA ]",
+            "then git clone https://github.com/eth-sri/ELINA.git",
             "cd ELINA",
             f"git checkout {commit_hash}",
             (
@@ -149,6 +149,7 @@ class ELINAInstaller(Installer):
             ),
             "make",
             "make install",
+            "fi",
             f"cd {installation_path}",
             "rm -rf ELINA",
             f"cp -r {cache_dir}/ELINA .",
@@ -210,10 +211,12 @@ class ERANInstaller(Installer):
             f"cd {gurobi_path}",
             "python setup.py install",
             f"cd {cache_dir}",
-            "rm -rf eran",
-            "git clone https://github.com/eth-sri/eran.git",
+            "if [ ! -e eran ]",
+            "then git clone https://github.com/eth-sri/eran.git",
             "cd eran",
             f"git checkout {commit_hash}",
+            "else cd eran",
+            "fi",
             f"cp -r tf_verify/* {site_packages_dir}",
         ]
         install_script = "; ".join(commands)

--- a/dnnv/_manage/linux/verifiers/marabou.py
+++ b/dnnv/_manage/linux/verifiers/marabou.py
@@ -97,6 +97,8 @@ class MarabouInstaller(Installer):
         python_version = f"python{python_major_version}.{python_minor_version}"
         site_packages_dir = f"{verifier_venv_path}/lib/{python_version}/site-packages/"
 
+        marabou_url = "https://github.com/NeuralNetworkVerification/Marabou.git"
+
         commands = [
             "set -ex",
             f"cd {verifier_venv_path.parent}",
@@ -111,11 +113,10 @@ class MarabouInstaller(Installer):
                 ' "onnxruntime>=1.7,<1.11"'
             ),
             f"cd {cache_dir}",
-            "rm -rf Marabou",
-            "git clone https://github.com/NeuralNetworkVerification/Marabou.git",
+            "if [ ! -e Marabou ]",
+            "then git clone https://github.com/NeuralNetworkVerification/Marabou.git",
             "cd Marabou",
             f"git checkout {commit_hash}",
-            "rm -rf build",
             "mkdir -p build",
             "cd build",
             "mkdir -p OpenBlas",
@@ -123,6 +124,8 @@ class MarabouInstaller(Installer):
             f"ln -s {openblas_path} {cache_dir}/Marabou/build/OpenBlas/installed",
             f"cmake -D OPENBLAS_DIR={cache_dir}/Marabou/build/OpenBlas ..",
             "cmake --build .",
+            "else cd Marabou/build",
+            "fi",
             f"cp -r ../maraboupy {site_packages_dir}",
         ]
         install_script = "; ".join(commands)

--- a/dnnv/_manage/linux/verifiers/mipverify.py
+++ b/dnnv/_manage/linux/verifiers/mipverify.py
@@ -17,7 +17,7 @@ from ..environment import (
 MIPVERIFY_RUNNER = """#!/bin/bash
 export GUROBI_HOME={gurobi_home}
 cd {venv_path}
-./julia --project=. $@
+./julia --project=. -g 0 --track-allocation=none --code-coverage=none -O0 $@
 """
 
 

--- a/dnnv/_manage/linux/verifiers/neurify.py
+++ b/dnnv/_manage/linux/verifiers/neurify.py
@@ -38,12 +38,14 @@ class NeurifyInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            "rm -rf Neurify",
-            "git clone https://github.com/dlshriver/Neurify.git",
+            "if [ ! -e Neurify ]",
+            "then git clone https://github.com/dlshriver/Neurify.git",
             "cd Neurify",
             f"git checkout {commit_hash}",
             "cd generic",
             f'make {ld_flags} LPFLAGS="" {include_flags}',
+            "else cd Neurify/generic",
+            "fi",
             f"cp src/neurify {installation_path}",
         ]
         install_script = "; ".join(commands)

--- a/dnnv/_manage/linux/verifiers/nnenum.py
+++ b/dnnv/_manage/linux/verifiers/nnenum.py
@@ -103,12 +103,6 @@ class NnenumInstaller(Installer):
             f"python -m venv {name}",
             f". {name}/bin/activate",
             "pip install --upgrade pip",
-            f"cd {cache_dir}",
-            f"rm -rf {name}",
-            "git clone https://github.com/stanleybak/nnenum.git",
-            f"cd {name}",
-            f"git checkout {commit_hash}",
-            # "pip install -r requirements.txt",
             (
                 "pip install"
                 ' "numpy>=1.19,<1.22"'
@@ -120,6 +114,13 @@ class NnenumInstaller(Installer):
                 ' "swiglpk"'
                 ' "termcolor"'
             ),
+            f"cd {cache_dir}",
+            f"if [ ! -e {name} ]",
+            "then git clone https://github.com/stanleybak/nnenum.git",
+            f"cd {name}",
+            f"git checkout {commit_hash}",
+            f"else cd {name}",
+            "fi",
             f"cp -r src/nnenum {site_packages_dir}",
         ]
         install_script = "; ".join(commands)

--- a/dnnv/_manage/linux/verifiers/planet.py
+++ b/dnnv/_manage/linux/verifiers/planet.py
@@ -35,8 +35,8 @@ class PlanetInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            "rm -rf planet",
-            "git clone https://github.com/progirep/planet.git",
+            "if [ ! -e planet ]",
+            "then git clone https://github.com/progirep/planet.git",
             "cd planet",
             f"git checkout {commit_hash}",
             "cd src",
@@ -52,6 +52,8 @@ class PlanetInstaller(Installer):
                 " main.o verifierContext.o supersetdatabase.o"
                 f" {library_options}"
             ),
+            "else cd planet/src",
+            "fi",
             f"cp planet {installation_path}",
         ]
         install_script = "; ".join(commands)

--- a/dnnv/_manage/linux/verifiers/reluplex.py
+++ b/dnnv/_manage/linux/verifiers/reluplex.py
@@ -19,11 +19,13 @@ class ReluplexInstaller(Installer):
         commands = [
             "set -ex",
             f"cd {cache_dir}",
-            "rm -rf ReluplexCav2017",
-            "git clone https://github.com/dlshriver/ReluplexCav2017.git",
+            "if [ ! -e ReluplexCav2017 ]",
+            "then git clone https://github.com/dlshriver/ReluplexCav2017.git",
             "cd ReluplexCav2017",
             f"git checkout {commit_hash}",
             "make",
+            "else cd ReluplexCav2017",
+            "fi",
             (
                 "cp"
                 " check_properties/generic_prover/generic_prover.elf"

--- a/tests/system_tests/test_verifiers/test_mnist.py
+++ b/tests/system_tests/test_verifiers/test_mnist.py
@@ -78,6 +78,8 @@ class MNISTTests(unittest.TestCase):
         excluded_verifiers = {
             "bab",  # too slow
             "babsb",  # too slow
+            "mipverify",  # too slow
+            "mipverify_HiGHS",  # too slow
             "planet",  # too slow
             "reluplex",  # too slow
             "verinet",  # returns error # TODO: fix?
@@ -99,12 +101,12 @@ class MNISTTests(unittest.TestCase):
                 result, _ = verifier.verify(phi, **VERIFIER_KWARGS.get(name, {}))
                 self.check_results(result, results)
 
-    @unittest.skip("Too slow")
     def test_convSmallRELU__Point(self):
         excluded_verifiers = {
             "bab",  # too slow
             "babsb",  # too slow
             "mipverify",  # too slow
+            "mipverify_HiGHS",  # too slow
             "planet",  # too slow
             "reluplex",  # doesn't support Conv
         }
@@ -132,7 +134,6 @@ class MNISTTests(unittest.TestCase):
             "bab",  # too slow
             "babsb",  # too slow
             "marabou",  # too slow
-            "mipverify",  # property not supported (multiple epsilon values) # TODO : fix? is this still the case?
             "mipverify_HiGHS",  # too slow
             "planet",  # too slow
             "reluplex",  # too slow

--- a/tests/system_tests/test_verifiers/test_opsupport.py
+++ b/tests/system_tests/test_verifiers/test_opsupport.py
@@ -1,0 +1,152 @@
+import os
+import unittest
+
+from system_tests.utils import network_artifact_dir, property_artifact_dir
+
+from dnnv import nn, properties
+from dnnv.properties import get_context
+from dnnv.verifiers import SAT, UNKNOWN, UNSAT
+from dnnv.verifiers.bab import BaB
+from dnnv.verifiers.babsb import BaBSB
+from dnnv.verifiers.eran import ERAN
+from dnnv.verifiers.marabou import Marabou
+from dnnv.verifiers.mipverify import MIPVerify
+from dnnv.verifiers.neurify import Neurify
+from dnnv.verifiers.nnenum import Nnenum
+from dnnv.verifiers.planet import Planet
+from dnnv.verifiers.reluplex import Reluplex
+from dnnv.verifiers.verinet import VeriNet
+
+RUNS_PER_PROP = int(os.environ.get("_DNNV_TEST_RUNS_PER_PROP", "1"))
+
+VERIFIERS = {
+    "bab": BaB,
+    "babsb": BaBSB,
+    "eran": ERAN,
+    "marabou": Marabou,
+    "mipverify": MIPVerify,
+    "neurify": Neurify,
+    "nnenum": Nnenum,
+    "planet": Planet,
+    "reluplex": Reluplex,
+    "verinet": VeriNet,
+}
+
+VERIFIERS = {
+    "bab": BaB,
+    "babsb": BaBSB,
+    "eran_deepzono": ERAN,
+    "eran_deeppoly": ERAN,
+    # "eran_refinezono": ERAN, # TODO : is_installed (needs to check for gurobi license)
+    # "eran_refinepoly": ERAN, # TODO : is_installed (needs to check for gurobi license)
+    "marabou": Marabou,
+    # "mipverify": MIPVerify, # TODO : is_installed (needs to check for gurobi license)
+    "mipverify_HiGHS": MIPVerify,
+    "neurify": Neurify,
+    "nnenum": Nnenum,
+    "planet": Planet,
+    "reluplex": Reluplex,
+    "verinet": VeriNet,
+}
+
+VERIFIER_KWARGS = {
+    "eran_deepzono": {"domain": "deepzono"},
+    "eran_deeppoly": {"domain": "deeppoly"},
+    "eran_refinezono": {"domain": "refinezono"},
+    "eran_refinepoly": {"domain": "refinepoly"},
+    "mipverify_HiGHS": {"optimizer": "HiGHS"},
+}
+
+
+@unittest.skipIf(
+    sum(v.is_installed() for v in VERIFIERS.values()) < 2,
+    "Not enough verifiers installed",
+)
+class OpSupportTests(unittest.TestCase):
+    def setUp(self):
+        self.reset_property_context()
+        for varname in [
+            "SEED",
+            "SHIFT",
+            "SCALE",
+            "EPSILON",
+            "INPUT_LAYER",
+            "OUTPUT_LAYER",
+        ]:
+            if varname in os.environ:
+                del os.environ[varname]
+
+    def reset_property_context(self):
+        get_context().reset()
+
+    def check_results(self, result, results):
+        if result == UNKNOWN:
+            return
+        results.append(result)
+        if len(results) == 1:
+            return
+        previous_result = results[-2]
+        self.assertEqual(result, previous_result)
+
+    def test_max_positive(self):
+        excluded_verifiers = {
+            "neurify",  # does not support MaxPool
+            "nnenum",  # does not support MaxPool
+            "reluplex",  # does not support MaxPool
+        }
+        excluded_configs = {}
+        for epsilon in [0.01, 0.1, 0.5, 1.0]:
+            os.environ["EPSILON"] = str(epsilon)
+            for i in range(RUNS_PER_PROP):
+                os.environ["SEED"] = str(i)
+                results = []
+                for name, verifier in VERIFIERS.items():
+                    if (name, epsilon) in excluded_configs:
+                        continue
+                    if name in excluded_verifiers:
+                        continue
+                    if not verifier.is_installed():
+                        continue
+                    self.reset_property_context()
+                    dnn = nn.parse(
+                        network_artifact_dir / "max_positive.onnx"
+                    ).simplify()
+                    phi = properties.parse(property_artifact_dir / "max_positive.py")
+                    phi.concretize(N=dnn)
+                    result, _ = verifier.verify(phi, **VERIFIER_KWARGS.get(name, {}))
+                    self.check_results(result, results)
+
+    def test_max_positive_nonstandard(self):
+        excluded_verifiers = {
+            "eran_deeppoly",  # segfaults # TODO: find out why (MaxPool not supported?)
+            "eran_deepzono",  # incorrect # TODO: find out why (MaxPool not supported?)
+            "neurify",  # does not support MaxPool
+            "nnenum",  # does not support MaxPool
+            "planet",  # does not support standalone Relus # TODO (fix this)
+            "reluplex",  # does not support MaxPool
+        }
+        excluded_configs = {}
+        for epsilon in [0.01, 0.1, 0.5, 1.0]:
+            os.environ["EPSILON"] = str(epsilon)
+            for i in range(RUNS_PER_PROP):
+                os.environ["SEED"] = str(i)
+                results = []
+                for name, verifier in VERIFIERS.items():
+                    if (name, epsilon) in excluded_configs:
+                        continue
+                    if name in excluded_verifiers:
+                        continue
+                    if not verifier.is_installed():
+                        continue
+                    self.reset_property_context()
+                    dnn = nn.parse(
+                        network_artifact_dir / "max_positive_nonstandard.onnx"
+                    ).simplify()
+                    phi = properties.parse(property_artifact_dir / "max_positive.py")
+                    phi.concretize(N=dnn)
+                    result, _ = verifier.verify(phi, **VERIFIER_KWARGS.get(name, {}))
+                    self.check_results(result, results)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/system_tests/test_verifiers/test_random.py
+++ b/tests/system_tests/test_verifiers/test_random.py
@@ -160,15 +160,10 @@ class RandomTests(unittest.TestCase):
     def test_random_conv_0(self):
         os.environ["OUTPUT_LAYER"] = "-1"
         excluded_configs = {
-            ("mipverify", 0.01),  # too slow
-            ("mipverify", 0.1),  # too slow
-            ("mipverify", 0.5),  # too slow
-            ("mipverify", 1.0),  # too slow
             ("reluplex", 0.01),  # conv unsupported
             ("reluplex", 0.1),  # conv unsupported
             ("reluplex", 0.5),  # conv unsupported
             ("reluplex", 1.0),  # conv unsupported
-            ("nnenum", 0.5),  # too slow
         }
         for epsilon in [0.01, 0.1, 0.5, 1.0]:
             os.environ["EPSILON"] = str(epsilon)
@@ -192,10 +187,6 @@ class RandomTests(unittest.TestCase):
     def test_random_conv_1(self):
         os.environ["OUTPUT_LAYER"] = "-1"
         excluded_configs = {
-            ("mipverify", 0.01),  # too slow
-            ("mipverify", 0.1),  # too slow
-            ("mipverify", 0.5),  # too slow
-            ("mipverify", 1.0),  # too slow
             ("reluplex", 0.01),  # conv unsupported
             ("reluplex", 0.1),  # conv unsupported
             ("reluplex", 0.5),  # conv unsupported
@@ -224,10 +215,6 @@ class RandomTests(unittest.TestCase):
     def test_random_conv_2(self):
         os.environ["OUTPUT_LAYER"] = "-1"
         excluded_configs = {
-            ("mipverify", 0.01),  # too slow
-            ("mipverify", 0.1),  # too slow
-            ("mipverify", 0.5),  # too slow
-            ("mipverify", 1.0),  # too slow
             ("reluplex", 0.01),  # conv unsupported
             ("reluplex", 0.1),  # conv unsupported
             ("reluplex", 0.5),  # conv unsupported
@@ -276,7 +263,6 @@ class RandomTests(unittest.TestCase):
     def test_hyperlocal_random_conv_0(self):
         os.environ["OUTPUT_LAYER"] = "-1"
         excluded_verifiers = {
-            "mipverify",
             "reluplex",
             "verinet",
         }
@@ -303,65 +289,6 @@ class RandomTests(unittest.TestCase):
                     phi = properties.parse(
                         property_artifact_dir / "hyperlocalrobustness.py"
                     )
-                    phi.concretize(N=dnn)
-                    result, _ = verifier.verify(phi, **VERIFIER_KWARGS.get(name, {}))
-                    self.check_results(result, results)
-
-    def test_max_positive(self):
-        excluded_verifiers = {
-            "neurify",  # does not support MaxPool
-            "nnenum",  # does not support MaxPool
-            "reluplex",  # does not support MaxPool
-        }
-        excluded_configs = {}
-        for epsilon in [0.01, 0.1, 0.5, 1.0]:
-            os.environ["EPSILON"] = str(epsilon)
-            for i in range(RUNS_PER_PROP):
-                os.environ["SEED"] = str(i)
-                results = []
-                for name, verifier in VERIFIERS.items():
-                    if (name, epsilon) in excluded_configs:
-                        continue
-                    if name in excluded_verifiers:
-                        continue
-                    if not verifier.is_installed():
-                        continue
-                    self.reset_property_context()
-                    dnn = nn.parse(
-                        network_artifact_dir / "max_positive.onnx"
-                    ).simplify()
-                    phi = properties.parse(property_artifact_dir / "max_positive.py")
-                    phi.concretize(N=dnn)
-                    result, _ = verifier.verify(phi, **VERIFIER_KWARGS.get(name, {}))
-                    self.check_results(result, results)
-
-    def test_max_positive_nonstandard(self):
-        excluded_verifiers = {
-            "eran_deeppoly",  # segfaults # TODO: find out why (MaxPool not supported?)
-            "eran_deepzono",  # incorrect # TODO: find out why (MaxPool not supported?)
-            "neurify",  # does not support MaxPool
-            "nnenum",  # does not support MaxPool
-            "planet",  # does not support standalone Relus # TODO (fix this)
-            "reluplex",  # does not support MaxPool
-        }
-        excluded_configs = {}
-        for epsilon in [0.01, 0.1, 0.5, 1.0]:
-            os.environ["EPSILON"] = str(epsilon)
-            for i in range(RUNS_PER_PROP):
-                os.environ["SEED"] = str(i)
-                results = []
-                for name, verifier in VERIFIERS.items():
-                    if (name, epsilon) in excluded_configs:
-                        continue
-                    if name in excluded_verifiers:
-                        continue
-                    if not verifier.is_installed():
-                        continue
-                    self.reset_property_context()
-                    dnn = nn.parse(
-                        network_artifact_dir / "max_positive_nonstandard.onnx"
-                    ).simplify()
-                    phi = properties.parse(property_artifact_dir / "max_positive.py")
                     phi.concretize(N=dnn)
                     result, _ = verifier.verify(phi, **VERIFIER_KWARGS.get(name, {}))
                     self.check_results(result, results)


### PR DESCRIPTION
Split ci jobs into system and unit tests to hopefully get some quicker results. Use the cache more aggressively, does not completely reinstall verifiers from scratch if found in the cache.