### PR TITLE
Add Slice Operation and better Dropout support

### DIFF
--- a/dnnv/nn/converters/onnx.py
+++ b/dnnv/nn/converters/onnx.py
@@ -83,6 +83,10 @@ class OnnxConverter(OperationVisitor):
             tensor_proto = onnx.numpy_helper.from_array(value, name=opname)
             self.initializer.append(tensor_proto)
             return tensor_proto
+        if isinstance(value, bool):
+            tensor_proto = onnx.numpy_helper.from_array(np.asarray(value), name=opname)
+            self.initializer.append(tensor_proto)
+            return tensor_proto
         if isinstance(value, (int, float)):
             tensor_proto = onnx.numpy_helper.from_array(
                 np.array(value, dtype=f"{type(value).__name__}32"), name=opname
@@ -289,10 +293,13 @@ class OnnxConverter(OperationVisitor):
 
         x = self._to_onnx_proto(operation.x, f"{opname}.x")
         ratio = self._to_onnx_proto(operation.ratio, f"{opname}.ratio")
+        training_mode = self._to_onnx_proto(
+            operation.training_mode, f"{opname}.training_mode"
+        )
 
         node = onnx.helper.make_node(
             op_type,
-            inputs=[x.name, ratio.name],
+            inputs=[x.name, ratio.name, training_mode.name],
             outputs=[opname],
             name=opname,
         )

--- a/dnnv/nn/converters/tensorflow.py
+++ b/dnnv/nn/converters/tensorflow.py
@@ -391,6 +391,7 @@ class TensorflowConverter(OperationVisitor):
         @self._cached
         def dropout_func(*inputs):
             x = _concretize([x_], inputs)
+            assert not operation.training_mode
             return x
 
         return dropout_func

--- a/dnnv/nn/operations/tensor.py
+++ b/dnnv/nn/operations/tensor.py
@@ -176,6 +176,25 @@ class Shape(Operation):
         return cls(*inputs, name=onnx_node.name)
 
 
+class Slice(Operation):
+    def __init__(
+        self, x, starts, ends, *, axes=None, steps=None, name: Optional[str] = None
+    ):
+        super().__init__(name=name)
+        self.x = x
+        self.starts = starts
+        self.ends = ends
+        self.axes = axes
+        self.steps = steps
+
+    @classmethod
+    def from_onnx(cls, onnx_node, *inputs):
+        attributes = {a.name: as_numpy(a) for a in onnx_node.attribute}
+        axes = attributes.get("axes")
+        steps = attributes.get("steps")
+        return cls(*inputs, axes=axes, steps=steps, name=onnx_node.name)
+
+
 class Tile(Operation):
     def __init__(self, x, repeats, *, name: Optional[str] = None):
         super().__init__(name=name)
@@ -232,6 +251,7 @@ __all__ = [
     "Reshape",
     "Resize",
     "Shape",
+    "Slice",
     "Tile",
     "Transpose",
     "Unsqueeze",

--- a/dnnv/nn/transformers/simplifiers/__init__.py
+++ b/dnnv/nn/transformers/simplifiers/__init__.py
@@ -15,6 +15,7 @@ from .convert_mul import ConvertMul
 from .convert_reshape_to_flatten import ConvertReshapeToFlatten
 from .convert_sub_to_add import ConvertSubToAdd
 from .drop_identities import (
+    DropDropout,
     DropIdentity,
     DropUnnecessaryConcat,
     DropUnnecessaryFlatten,
@@ -35,6 +36,7 @@ DEFAULT_SIMPLIFIERS = [
     ConvertMul,
     ConvertReshapeToFlatten,
     ConvertSubToAdd,
+    DropDropout,
     DropIdentity,
     DropUnnecessaryConcat,
     DropUnnecessaryFlatten,

--- a/dnnv/nn/transformers/simplifiers/drop_identities.py
+++ b/dnnv/nn/transformers/simplifiers/drop_identities.py
@@ -3,6 +3,13 @@ from ...graph import OperationGraph
 from .base import Simplifier
 
 
+class DropDropout(Simplifier):
+    def visit_Dropout(self, operation: operations.Dropout):
+        if operation.training_mode:
+            return operation
+        return operation.x
+
+
 class DropIdentity(Simplifier):
     def visit_Identity(self, operation: operations.Identity):
         return operation.x
@@ -36,6 +43,7 @@ class DropUnnecessaryRelu(Simplifier):
 
 
 __all__ = [
+    "DropDropout",
     "DropIdentity",
     "DropUnnecessaryConcat",
     "DropUnnecessaryFlatten",

--- a/dnnv/nn/visitors.py
+++ b/dnnv/nn/visitors.py
@@ -317,6 +317,28 @@ class PrintVisitor(OperationVisitor):
         self.print_op_id(operation)
         print(f"Sigmoid({self.get_op_id(operation.x)})")
 
+    def visit_Slice(self, operation: operations.Slice) -> None:
+        self.generic_visit(operation)
+        self.print_op_id(operation)
+        axes = (
+            f", axes={self.get_op_id(operation.axes)}"
+            if operation.axes is not None
+            else ""
+        )
+        steps = (
+            f", steps={self.get_op_id(operation.steps)}"
+            if operation.steps is not None
+            else ""
+        )
+        print(
+            "Slice("
+            f"{self.get_op_id(operation.x)}, "
+            f"{self.get_op_id(operation.starts)}, "
+            f"{self.get_op_id(operation.ends)}"
+            f"{axes}{steps}"
+            ")"
+        )
+
     def visit_Sign(self, operation: operations.Sign) -> None:
         self.generic_visit(operation)
         self.print_op_id(operation)

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Atan.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Atan.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_AveragePool.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_AveragePool.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 import pytest
 
 from dnnv.nn.converters.onnx import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_BatchNormalization.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_BatchNormalization.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Cast.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Cast.py
@@ -1,6 +1,6 @@
 import numpy as np
 import onnx
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Concat.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Concat.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Conv.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Conv.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_ConvTranspose.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_ConvTranspose.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 import pytest
 
 from dnnv.nn.converters.onnx import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Div.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Div.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Dropout.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Dropout.py
@@ -1,6 +1,5 @@
 import numpy as np
-import onnxruntime
-import pytest
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Elu.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Elu.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 import pytest
 
 from dnnv.nn.converters.onnx import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Expand.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Expand.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Flatten.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Flatten.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Gather.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Gather.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 import pytest
 
 from dnnv.nn.converters.onnx import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Gemm.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Gemm.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_GlobalAveragePool.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_GlobalAveragePool.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_MatMul.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_MatMul.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_MaxPool.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_MaxPool.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 import pytest
 
 from dnnv.nn.converters.onnx import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Mul.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Mul.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 import pytest
 
 from dnnv.nn.converters.onnx import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Relu.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Relu.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Reshape.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Reshape.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 import pytest
 
 from dnnv.nn.converters.onnx import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Sigmoid.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Sigmoid.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Slice.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Slice.py
@@ -1,0 +1,143 @@
+import numpy as np
+import onnxruntime.backend
+
+from dnnv.nn.converters.onnx import *
+from dnnv.nn.operations import *
+
+
+def check(op, inputs, outputs):
+    onnx_model = convert(OperationGraph([op]))
+
+    results = onnxruntime.backend.run(onnx_model, inputs)
+    assert len(results) == len(outputs)
+    for result, output in zip(results, outputs):
+        assert result.shape == output.shape
+        assert np.allclose(result, output)
+
+
+def test_Slice():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 0], dtype=np.int64)
+    ends = np.array([3, 10], dtype=np.int64)
+    axes = np.array([0, 1], dtype=np.int64)
+    steps = np.array([1, 1], dtype=np.int64)
+    y = x[0:3, 0:10]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+    # non-constant input tensor
+    x_input_op = Input((20, 10, 5), np.dtype(np.float32))
+    op = Slice(x_input_op, starts, ends, axes=axes, steps=steps)
+    check(op, [x], [y])
+
+    # non-constant starts input
+    starts_input_op = Input((2,), np.dtype(np.int64))
+    op = Slice(x, starts_input_op, ends, axes=axes, steps=steps)
+    check(op, [starts], [y])
+
+    # non-constant ends input
+    ends_input_op = Input((2,), np.dtype(np.int64))
+    op = Slice(x, starts, ends_input_op, axes=axes, steps=steps)
+    check(op, [ends], [y])
+
+    # non-constant axes input
+    axes_input_op = Input((2,), np.dtype(np.int64))
+    op = Slice(x, starts, ends, axes=axes_input_op, steps=steps)
+    check(op, [axes], [y])
+
+    # non-constant steps input
+    steps_input_op = Input((2,), np.dtype(np.int64))
+    op = Slice(x, starts, ends, axes=axes, steps=steps_input_op)
+    check(op, [steps], [y])
+
+
+def test_Slice_default_axes():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 0, 3], dtype=np.int64)
+    ends = np.array([20, 10, 4], dtype=np.int64)
+    y = x[:, :, 3:4]
+
+    op = Slice(x, starts, ends)
+    check(op, [], [y])
+
+
+def test_Slice_default_steps():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 0, 3], dtype=np.int64)
+    ends = np.array([20, 10, 4], dtype=np.int64)
+    axes = np.array([0, 1, 2], dtype=np.int64)
+    y = x[:, :, 3:4]
+
+    op = Slice(x, starts, ends, axes=axes)
+    check(op, [], [y])
+
+
+def test_Slice_end_out_of_bounds():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([1], dtype=np.int64)
+    ends = np.array([1000], dtype=np.int64)
+    axes = np.array([1], dtype=np.int64)
+    steps = np.array([1], dtype=np.int64)
+    y = x[:, 1:1000]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+
+def test_Slice_neg():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0], dtype=np.int64)
+    ends = np.array([-1], dtype=np.int64)
+    axes = np.array([1], dtype=np.int64)
+    steps = np.array([1], dtype=np.int64)
+    y = x[:, 0:-1]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+
+def test_Slice_neg_steps():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([20, 10, 4], dtype=np.int64)
+    ends = np.array([0, 0, 1], dtype=np.int64)
+    axes = np.array([0, 1, 2], dtype=np.int64)
+    steps = np.array([-1, -3, -2]).astype(np.int64)
+    y = x[20:0:-1, 10:0:-3, 4:1:-2]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+
+def test_Slice_negative_axes():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 0, 3], dtype=np.int64)
+    ends = np.array([20, 10, 4], dtype=np.int64)
+    axes = np.array([0, -2, -1], dtype=np.int64)
+    y = x[:, :, 3:4]
+
+    op = Slice(x, starts, ends, axes=axes)
+    check(op, [], [y])
+
+
+def test_Slice_start_out_of_bounds():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([1000], dtype=np.int64)
+    ends = np.array([1000], dtype=np.int64)
+    axes = np.array([1], dtype=np.int64)
+    steps = np.array([1], dtype=np.int64)
+    y = x[:, 1000:1000]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+
+def test_Slice_unordered_axes():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 3, 0], dtype=np.int64)
+    ends = np.array([10, 4, 20], dtype=np.int64)
+    axes = np.array([-2, 2, 0], dtype=np.int64)
+    y = x[:, :, 3:4]
+
+    op = Slice(x, starts, ends, axes=axes)
+    check(op, [], [y])

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Sub.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Sub.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 import pytest
 
 from dnnv.nn.converters.onnx import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Tanh.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Tanh.py
@@ -1,5 +1,5 @@
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_onnx/test_Transpose.py
+++ b/tests/unit_tests/test_nn/test_converters/test_onnx/test_Transpose.py
@@ -1,7 +1,7 @@
 import itertools
 
 import numpy as np
-import onnxruntime
+import onnxruntime.backend
 
 from dnnv.nn.converters.onnx import *
 from dnnv.nn.operations import *

--- a/tests/unit_tests/test_nn/test_converters/test_tensorflow/test_Slice.py
+++ b/tests/unit_tests/test_nn/test_converters/test_tensorflow/test_Slice.py
@@ -1,0 +1,139 @@
+import numpy as np
+import onnxruntime.backend
+
+from dnnv.nn.converters.tensorflow import *
+from dnnv.nn.operations import *
+
+
+def check(op, inputs, outputs):
+    tf_op = TensorflowConverter().visit(op)
+    result = tf_op(*inputs)
+    assert np.allclose(result, outputs)
+
+
+def test_Slice():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 0], dtype=np.int64)
+    ends = np.array([3, 10], dtype=np.int64)
+    axes = np.array([0, 1], dtype=np.int64)
+    steps = np.array([1, 1], dtype=np.int64)
+    y = x[0:3, 0:10]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+    # non-constant input tensor
+    x_input_op = Input((20, 10, 5), np.dtype(np.float32))
+    op = Slice(x_input_op, starts, ends, axes=axes, steps=steps)
+    check(op, [x], [y])
+
+    # non-constant starts input
+    starts_input_op = Input((2,), np.dtype(np.int64))
+    op = Slice(x, starts_input_op, ends, axes=axes, steps=steps)
+    check(op, [starts], [y])
+
+    # non-constant ends input
+    ends_input_op = Input((2,), np.dtype(np.int64))
+    op = Slice(x, starts, ends_input_op, axes=axes, steps=steps)
+    check(op, [ends], [y])
+
+    # non-constant axes input
+    axes_input_op = Input((2,), np.dtype(np.int64))
+    op = Slice(x, starts, ends, axes=axes_input_op, steps=steps)
+    check(op, [axes], [y])
+
+    # non-constant steps input
+    steps_input_op = Input((2,), np.dtype(np.int64))
+    op = Slice(x, starts, ends, axes=axes, steps=steps_input_op)
+    check(op, [steps], [y])
+
+
+def test_Slice_default_axes():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 0, 3], dtype=np.int64)
+    ends = np.array([20, 10, 4], dtype=np.int64)
+    y = x[:, :, 3:4]
+
+    op = Slice(x, starts, ends)
+    check(op, [], [y])
+
+
+def test_Slice_default_steps():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 0, 3], dtype=np.int64)
+    ends = np.array([20, 10, 4], dtype=np.int64)
+    axes = np.array([0, 1, 2], dtype=np.int64)
+    y = x[:, :, 3:4]
+
+    op = Slice(x, starts, ends, axes=axes)
+    check(op, [], [y])
+
+
+def test_Slice_end_out_of_bounds():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([1], dtype=np.int64)
+    ends = np.array([1000], dtype=np.int64)
+    axes = np.array([1], dtype=np.int64)
+    steps = np.array([1], dtype=np.int64)
+    y = x[:, 1:1000]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+
+def test_Slice_neg():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0], dtype=np.int64)
+    ends = np.array([-1], dtype=np.int64)
+    axes = np.array([1], dtype=np.int64)
+    steps = np.array([1], dtype=np.int64)
+    y = x[:, 0:-1]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+
+def test_Slice_neg_steps():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([20, 10, 4], dtype=np.int64)
+    ends = np.array([0, 0, 1], dtype=np.int64)
+    axes = np.array([0, 1, 2], dtype=np.int64)
+    steps = np.array([-1, -3, -2]).astype(np.int64)
+    y = x[20:0:-1, 10:0:-3, 4:1:-2]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+
+def test_Slice_negative_axes():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 0, 3], dtype=np.int64)
+    ends = np.array([20, 10, 4], dtype=np.int64)
+    axes = np.array([0, -2, -1], dtype=np.int64)
+    y = x[:, :, 3:4]
+
+    op = Slice(x, starts, ends, axes=axes)
+    check(op, [], [y])
+
+
+def test_Slice_start_out_of_bounds():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([1000], dtype=np.int64)
+    ends = np.array([1000], dtype=np.int64)
+    axes = np.array([1], dtype=np.int64)
+    steps = np.array([1], dtype=np.int64)
+    y = x[:, 1000:1000]
+
+    op = Slice(x, starts, ends, axes=axes, steps=steps)
+    check(op, [], [y])
+
+
+def test_Slice_unordered_axes():
+    x = np.random.randn(20, 10, 5).astype(np.float32)
+    starts = np.array([0, 3, 0], dtype=np.int64)
+    ends = np.array([10, 4, 20], dtype=np.int64)
+    axes = np.array([-2, 2, 0], dtype=np.int64)
+    y = x[:, :, 3:4]
+
+    op = Slice(x, starts, ends, axes=axes)
+    check(op, [], [y])

--- a/tests/unit_tests/test_nn/test_visitors/test_PrintVisitor.py
+++ b/tests/unit_tests/test_nn/test_visitors/test_PrintVisitor.py
@@ -547,6 +547,38 @@ Sign_0                          : Sign(Input_0)
     assert captured.out == expected_output
 
 
+def test_Slice(capsys):
+    input_op = Input((1, 5), np.dtype(np.float32))
+    slice_op_0 = Slice(input_op, np.array([0, 1]), np.array([1, 4]))
+    PrintVisitor().visit(slice_op_0)
+    captured = capsys.readouterr()
+    expected_output = """\
+Input_0                         : Input((1, 5), dtype=float32)
+Slice_0                         : Slice(Input_0, [0 1], [1 4])
+"""
+    assert captured.out == expected_output
+
+    slice_op_1 = Slice(input_op, np.array([1]), np.array([4]), axes=np.array([1]))
+    PrintVisitor().visit(slice_op_1)
+    captured = capsys.readouterr()
+    expected_output = """\
+Input_0                         : Input((1, 5), dtype=float32)
+Slice_0                         : Slice(Input_0, [1], [4], axes=[1])
+"""
+    assert captured.out == expected_output
+
+    slice_op_2 = Slice(
+        input_op, np.array([1]), np.array([4]), axes=np.array([1]), steps=np.array([2])
+    )
+    PrintVisitor().visit(slice_op_2)
+    captured = capsys.readouterr()
+    expected_output = """\
+Input_0                         : Input((1, 5), dtype=float32)
+Slice_0                         : Slice(Input_0, [1], [4], axes=[1], steps=[2])
+"""
+    assert captured.out == expected_output
+
+
 def test_Softmax(capsys):
     input_op = Input((1, 5), np.dtype(np.float32))
     softmax_op = Softmax(input_op)


### PR DESCRIPTION
Adds the Slice operation and improves support for Dropout by adding the optional `training_mode` input. Also adds a simplifier that removes Dropout operations for which `training_mode` is not enabled, since they are a no-op.