### PR TITLE
fix: special case for trivial (network-free) properties

### DIFF
--- a/dnnv/verifiers/common/base.py
+++ b/dnnv/verifiers/common/base.py
@@ -4,7 +4,18 @@ import tempfile
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 from dnnv.properties import Expression, LogicalExpression
 
@@ -23,7 +34,7 @@ from .results import SAT, UNSAT, PropertyCheckResult
 class Parameter:
     def __init__(
         self,
-        dtype: Type,
+        dtype: Callable[[Any], Any],
         default: Optional[Any] = None,
         choices: Optional[List[Any]] = None,
         help: Optional[str] = None,
@@ -43,7 +54,7 @@ class Parameter:
         self.choices = choices
         self.help = help
 
-    def as_type(self, value):
+    def as_type(self, value: Any):
         return self.type(value) if value is not None else None
 
 
@@ -143,13 +154,13 @@ class Verifier(ABC):
         return is_valid
 
     @abstractmethod
-    def build_inputs(self, prop: Property) -> Tuple[Any, ...]:
+    def build_inputs(self, prop: Property) -> Sequence:  # pragma: no cover
         raise NotImplementedError()
 
     @abstractmethod
     def parse_results(
         self, prop: Property, results: Any
-    ) -> Tuple[PropertyCheckResult, Optional[Any]]:
+    ) -> Tuple[PropertyCheckResult, Optional[Any]]:  # pragma: no cover
         raise NotImplementedError()
 
 

--- a/dnnv/verifiers/common/base.py
+++ b/dnnv/verifiers/common/base.py
@@ -116,7 +116,11 @@ class Verifier(ABC):
                 tempfile.tempdir = tempdir
                 result = UNSAT
                 for subproperty in self.reduce_property():
-                    subproperty_result, cex = self.check(subproperty)
+                    is_trivial, *trivial_result = subproperty.is_trivial()
+                    if is_trivial:
+                        subproperty_result, cex = trivial_result[0]
+                    else:
+                        subproperty_result, cex = self.check(subproperty)
                     result |= subproperty_result
                     if result == SAT:
                         if cex is not None:

--- a/dnnv/verifiers/common/base.py
+++ b/dnnv/verifiers/common/base.py
@@ -119,6 +119,9 @@ class Verifier(ABC):
                     is_trivial, *trivial_result = subproperty.is_trivial()
                     if is_trivial:
                         subproperty_result, cex = trivial_result[0]
+                        self.logger.warning(
+                            "Property is trivially %s.", subproperty_result
+                        )
                     else:
                         subproperty_result, cex = self.check(subproperty)
                     result |= subproperty_result

--- a/dnnv/verifiers/common/reductions/base.py
+++ b/dnnv/verifiers/common/reductions/base.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Any, Iterator, Optional, Tuple, Type
+from typing import Any, Iterator, Optional, Tuple, Type, Union
 
 from dnnv.errors import DNNVError
 from dnnv.properties import Expression
+
+from ..results import PropertyCheckResult
 
 
 class ReductionError(DNNVError):
@@ -10,6 +12,12 @@ class ReductionError(DNNVError):
 
 
 class Property:
+    @abstractmethod
+    def is_trivial(
+        self,
+    ) -> Union[Tuple[bool], Tuple[bool, Tuple[PropertyCheckResult, Any]]]:
+        raise NotImplementedError()
+
     @abstractmethod
     def validate_counter_example(self, cex: Any) -> Tuple[bool, Optional[str]]:
         raise NotImplementedError()

--- a/dnnv/verifiers/common/reductions/base.py
+++ b/dnnv/verifiers/common/reductions/base.py
@@ -11,7 +11,7 @@ class ReductionError(DNNVError):
     pass
 
 
-class Property:
+class Property(ABC):
     @abstractmethod
     def is_trivial(
         self,

--- a/tests/unit_tests/test_verifiers/test_common/test_base.py
+++ b/tests/unit_tests/test_verifiers/test_common/test_base.py
@@ -1,0 +1,177 @@
+from functools import partial
+
+import numpy as np
+import pytest
+
+from dnnv.nn import OperationGraph, operations
+from dnnv.properties.expressions import *
+from dnnv.verifiers.common.base import Parameter as VerifierParameter
+from dnnv.verifiers.common.base import Verifier
+from dnnv.verifiers.common.errors import VerifierError
+from dnnv.verifiers.common.executors import VerifierExecutor
+from dnnv.verifiers.common.reductions.iopolytope import (
+    HalfspacePolytope,
+    IOPolytopeReduction,
+)
+from dnnv.verifiers.common.results import SAT, UNSAT
+
+
+class MockExecutor(VerifierExecutor):
+    def run(self):
+        return True
+
+
+class MockVerifierUNSAT(Verifier):
+    executor = MockExecutor
+    reduction = partial(IOPolytopeReduction, HalfspacePolytope, HalfspacePolytope)
+
+    def build_inputs(self, prop):
+        return ("mock",)
+
+    def parse_results(self, prop, results):
+        return UNSAT, None
+
+
+class MockVerifierSAT(Verifier):
+    executor = MockExecutor
+    parameters = {"cex": VerifierParameter(np.asarray)}
+    reduction = partial(IOPolytopeReduction, HalfspacePolytope, HalfspacePolytope)
+
+    def build_inputs(self, prop):
+        return ("mock",)
+
+    def parse_results(self, prop, results):
+        return SAT, self.parameter_values["cex"]
+
+
+def test_Verifier_init():
+    x = Symbol("x")
+    N = Network("N")
+    expression = Forall(
+        x, Implies(And(Constant(0) <= x, x <= Constant(1)), N(x) > Constant(0))
+    )
+
+    verifier = MockVerifierUNSAT(expression)
+    assert len(verifier.parameter_values) == 0
+    with pytest.raises(VerifierError):
+        verifier = MockVerifierUNSAT(expression, extra_param=123)
+
+    verifier = MockVerifierSAT(expression)
+    assert len(verifier.parameter_values) == 1
+    assert verifier.parameter_values["cex"] is None
+
+    verifier = MockVerifierSAT(expression, cex=123)
+    assert len(verifier.parameter_values) == 1
+    assert verifier.parameter_values["cex"] == 123
+
+
+def test_Verifier_verify_unsat():
+    x = Symbol("x")
+    N = Network("N")
+    N.concretize(
+        OperationGraph(
+            [
+                operations.Mul(
+                    2.0,
+                    operations.Relu(
+                        operations.Mul(
+                            2.0, operations.Input((-1, 1), np.dtype("float32"))
+                        )
+                    ),
+                )
+            ]
+        )
+    )
+    expression = Forall(
+        x, Implies(And(Constant(0) <= x, x <= Constant(1)), N(x) > Constant(0))
+    )
+    result = MockVerifierUNSAT.verify(expression)
+    assert result[0] == UNSAT
+
+
+def test_Verifier_verify_sat():
+    x = Symbol("x")
+    N = Network("N")
+    N.concretize(
+        OperationGraph(
+            [
+                operations.Mul(
+                    2.0,
+                    operations.Relu(
+                        operations.Mul(
+                            2.0, operations.Input((-1, 1), np.dtype("float32"))
+                        )
+                    ),
+                )
+            ]
+        )
+    )
+    expression = Forall(
+        x, Implies(And(Constant(0) <= x, x <= Constant(1)), N(x) < Constant(0))
+    )
+    result = MockVerifierSAT.verify(expression)
+    assert result[0] == SAT
+
+    result = MockVerifierSAT.verify(
+        expression, cex=np.asarray([[0.5]], dtype=np.float32)
+    )
+    assert result[0] == SAT
+
+    with pytest.raises(VerifierError):
+        result = MockVerifierSAT.verify(
+            expression, cex=np.asarray([[-1]], dtype=np.float32)
+        )
+
+
+def test_Verifier_verify_concrete():
+    expression = Constant(False)
+    result = MockVerifierSAT.verify(expression)
+    assert result[0] == SAT
+    assert result[1] is None
+
+    expression = Constant(True)
+    result = MockVerifierSAT.verify(expression)
+    assert result[0] == UNSAT
+    assert result[1] is None
+
+
+def test_Verifier_verify_trivial():
+    x = Symbol("x")
+    x.ctx.shapes[x] = (1, 1)
+    x.ctx.types[x] = np.dtype(np.float32)
+    expression = Forall(
+        x, Implies(And(Constant(0) <= x, x <= Constant(1)), Constant(True))
+    )
+    result = MockVerifierUNSAT.verify(expression)
+    assert result[0] == UNSAT
+
+    expression = Forall(
+        x, Implies(And(Constant(0) <= x, x <= Constant(1)), Constant(False))
+    )
+    result = MockVerifierSAT.verify(expression)
+    assert result[0] == SAT
+    assert result[1] is not None
+
+
+def test_Verifier_verify_trivial_with_hpoly():
+    x = Symbol("x")
+    x.ctx.shapes[x] = (1, 2)
+    x.ctx.types[x] = np.dtype(np.float32)
+    expression = Forall(
+        x,
+        Implies(
+            And(Constant(0) <= x, x <= Constant(1), x[0, 0] < x[0, 1]), Constant(True)
+        ),
+    )
+    result = MockVerifierUNSAT.verify(expression)
+    assert result[0] == UNSAT
+
+    expression = Forall(
+        x,
+        Implies(
+            And(Constant(0) <= x, x <= Constant(1), x[0, 0] < x[0, 1]), Constant(False)
+        ),
+    )
+    result = MockVerifierSAT.verify(expression)
+    assert result[0] == SAT
+    assert result[1] is not None

--- a/tests/unit_tests/test_verifiers/test_common/test_reductions/test_base.py
+++ b/tests/unit_tests/test_verifiers/test_common/test_reductions/test_base.py
@@ -1,0 +1,42 @@
+import pytest
+
+from dnnv.properties.expressions import Constant
+from dnnv.verifiers.common.reductions.base import Property, Reduction
+
+
+def test_instantiate_Property():
+    with pytest.raises(TypeError):
+        _ = Property()
+
+
+def test_Property_abstract_methods():
+    class FakeProperty(Property):
+        def is_trivial(self):
+            return super().is_trivial()
+
+        def validate_counter_example(self, cex):
+            return super().validate_counter_example(cex)
+
+    prop = FakeProperty()
+
+    with pytest.raises(NotImplementedError):
+        prop.is_trivial()
+
+    with pytest.raises(NotImplementedError):
+        prop.validate_counter_example(None)
+
+
+def test_instantiate_Reduction():
+    with pytest.raises(TypeError):
+        _ = Property()
+
+
+def test_Reduction_abstract_methods():
+    class FakeReduction(Reduction):
+        def reduce_property(self, expression):
+            return super().reduce_property(expression)
+
+    reduction = FakeReduction()
+
+    with pytest.raises(NotImplementedError):
+        reduction.reduce_property(Constant(True))


### PR DESCRIPTION
This is a fix for an issue identified in #94, specifically the case where DNNV partially solves a property during reduction such that it no longer contains a neural network to verify. We add a special case for these trivial subproperties, and immediately return a solution rather than an error.