### PR TITLE
fix: batch norm issues

### DIFF
--- a/dnnv/nn/operations/base.py
+++ b/dnnv/nn/operations/base.py
@@ -83,12 +83,6 @@ class Operation(metaclass=Op):
         for op_cls in get_subclasses(cls):
             if op_type == op_cls.__name__:
                 operation = op_cls.from_onnx(onnx_node, *inputs)
-                if all(not isinstance(i, Operation) for i in inputs) and isinstance(
-                    operation, Operation
-                ):
-                    logger.warning(
-                        "Operation on constant inputs returned non-constant."
-                    )
                 return operation
         raise ValueError(f"Unimplemented operation type: {op_type}")
 

--- a/dnnv/nn/operations/tensor.py
+++ b/dnnv/nn/operations/tensor.py
@@ -207,7 +207,6 @@ class Slice(Operation):
 
     @classmethod
     def from_onnx(cls, onnx_node, *inputs):
-        attributes = {a.name: as_numpy(a) for a in onnx_node.attribute}
         return cls(*inputs, name=onnx_node.name)
 
 
@@ -247,16 +246,6 @@ class Unsqueeze(Operation):
     @classmethod
     def from_onnx(cls, onnx_node, *inputs):
         attributes = {a.name: as_numpy(a) for a in onnx_node.attribute}
-        if isinstance(inputs[0], np.ndarray):
-            if len(inputs) == 2:
-                axes = inputs[1]
-            else:
-                axes = attributes["axes"]
-            if not isinstance(axes, Operation):
-                a = inputs[0]
-                for axis in axes:
-                    a = np.expand_dims(a, axis)
-                return a
         if len(inputs) == 2:
             return cls(*inputs, name=onnx_node.name)
         axes = attributes["axes"]

--- a/dnnv/nn/transformers/simplifiers/convert_batch_norm.py
+++ b/dnnv/nn/transformers/simplifiers/convert_batch_norm.py
@@ -2,7 +2,7 @@ from copy import copy
 
 import numpy as np
 
-from ... import operations, OperationGraph
+from ... import OperationGraph, operations
 from ...analyzers import SplitAnalysis
 from .base import Simplifier
 

--- a/dnnv/nn/transformers/simplifiers/convert_batch_norm.py
+++ b/dnnv/nn/transformers/simplifiers/convert_batch_norm.py
@@ -2,7 +2,7 @@ from copy import copy
 
 import numpy as np
 
-from ... import operations
+from ... import operations, OperationGraph
 from ...analyzers import SplitAnalysis
 from .base import Simplifier
 
@@ -12,6 +12,13 @@ class ConvertBatchNorm(Simplifier):
 
     def visit_BatchNormalization(self, operation: operations.BatchNormalization):
         input_op = operation.x
+        if (
+            isinstance(operation.scale, operations.Operation)
+            or isinstance(operation.bias, operations.Operation)
+            or isinstance(operation.mean, operations.Operation)
+            or isinstance(operation.variance, operations.Operation)
+        ):
+            return operation
         if (
             isinstance(input_op, operations.Conv)
             and not self.analysis["is_split"][input_op]
@@ -40,26 +47,23 @@ class ConvertBatchNorm(Simplifier):
             a = operation.scale / std
             b = operation.bias - operation.mean * a
             return operations.Gemm(input_op, np.diag(a), b)
-        elif isinstance(input_op, operations.Input):
-            input_shape = input_op.shape
-            input_dtype = input_op.dtype
-            if len(input_shape) == 2:
-                std = np.sqrt(operation.variance + operation.epsilon)
-                a = operation.scale / std
-                b = operation.bias - operation.mean * a
-                return operations.Gemm(input_op, np.diag(a), b)
-            elif len(input_shape) == 4:
-                c = operation.mean.shape[0]
-                std = np.sqrt(operation.variance + operation.epsilon)
-                W = np.zeros(
-                    (c, c, 1, 1), dtype=input_dtype
-                )  # identity kernel (H, W, inC, outC)
-                for i in range(c):
-                    W[i, i, 0, 0] = operation.scale[i] / std[i]
-                b = operation.bias - operation.scale * operation.mean / std
-                op = operations.Conv(input_op, W, b)
-                return op
-        # TODO : in what other scenarios can BatchNorm be converted?
+        input_shape, input_dtype = OperationGraph([input_op]).output_details[0]
+        if len(input_shape) == 2:
+            std = np.sqrt(operation.variance + operation.epsilon)
+            a = operation.scale / std
+            b = operation.bias - operation.mean * a
+            return operations.Gemm(input_op, np.diag(a), b)
+        elif len(input_shape) == 4:
+            c = operation.mean.shape[0]
+            std = np.sqrt(operation.variance + operation.epsilon)
+            W = np.zeros(
+                (c, c, 1, 1), dtype=input_dtype
+            )  # identity kernel (H, W, inC, outC)
+            for i in range(c):
+                W[i, i, 0, 0] = operation.scale[i] / std[i]
+            b = operation.bias - operation.scale * operation.mean / std
+            op = operations.Conv(input_op, W, b)
+            return op
         return operation
 
 

--- a/tests/unit_tests/test_nn/test_converters/test_tensorflow/test_BatchNormalization.py
+++ b/tests/unit_tests/test_nn/test_converters/test_tensorflow/test_BatchNormalization.py
@@ -53,3 +53,30 @@ def test_BatchNormalization_x_is_op():
     )
     assert np.all(result >= (y - TOL))
     assert np.all(result <= (y + TOL))
+
+
+def test_BatchNormalization_multiple_input_ops():
+    x = np.arange(12).astype(np.float32).reshape((1, 3, 2, 2))
+    scale = np.full(3, 2.0, dtype=np.float32)
+    bias = np.full(3, 0.0, dtype=np.float32)
+    mean = np.full(3, 5.5, dtype=np.float32)
+    var = np.full(3, 11.9, dtype=np.float32)
+
+    x_op = Input((1, 3, 2, 2), np.dtype(np.float32))
+    mean_op = Input((3,), np.dtype(np.float32))
+    var_op = Input((3,), np.dtype(np.float32))
+    op = BatchNormalization(x_op, scale, bias, mean_op, var_op)
+    tf_op = TensorflowConverter().visit(op)
+    result = tf_op(x, mean, var).numpy()
+    y = np.array(
+        [
+            [
+                [[-3.1887393, -2.6089685], [-2.0291977, -1.4494269]],
+                [[-0.8696561, -0.28988528], [0.28988552, 0.8696561]],
+                [[1.4494271, 2.0291982], [2.6089687, 3.1887393]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+    assert np.all(result >= (y - TOL))
+    assert np.all(result <= (y + TOL))

--- a/tests/unit_tests/test_nn/test_converters/test_tensorflow/test_base.py
+++ b/tests/unit_tests/test_nn/test_converters/test_tensorflow/test_base.py
@@ -6,11 +6,11 @@ from dnnv.utils import get_subclasses
 
 
 def test_missing():
-    class FakeOperation:
+    class _FakeOperation(Operation):
         pass
 
     with pytest.raises(ValueError) as excinfo:
-        TensorflowConverter().visit(FakeOperation())
+        TensorflowConverter().visit(_FakeOperation())
     assert str(excinfo.value).startswith(
         "Tensorflow converter not implemented for operation type"
     )
@@ -19,6 +19,8 @@ def test_missing():
 def test_has_all():
     converter = TensorflowConverter()
     for operation in get_subclasses(Operation):
+        if operation.__name__.startswith("_"):
+            continue
         assert hasattr(converter, f"visit_{operation}")
 
 

--- a/tests/unit_tests/test_nn/test_operations/test_base/test_Operation.py
+++ b/tests/unit_tests/test_nn/test_operations/test_base/test_Operation.py
@@ -66,7 +66,7 @@ def test_from_onnx_Elu():
     assert op_from_onnx.alpha == 0.5
 
 
-def test_from_onnx_Elu():
+def test_from_onnx_Elu_unimplemented():
     input_op = Input(np.array([-1, 5]), np.dtype(np.float32))
 
     add_node = onnx.helper.make_node(

--- a/tests/unit_tests/test_nn/test_operations/test_base/test_Operation.py
+++ b/tests/unit_tests/test_nn/test_operations/test_base/test_Operation.py
@@ -52,8 +52,6 @@ def test_from_onnx_Mul_constants(caplog):
     assert op_from_onnx.a == 2
     assert op_from_onnx.b == 5
 
-    assert "Operation on constant inputs returned non-constant." in caplog.text
-
 
 def test_from_onnx_Elu():
     input_op = Input(np.array([-1, 5]), np.dtype(np.float32))

--- a/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_batch_norm.py
+++ b/tests/unit_tests/test_nn/test_transformers/test_simplifiers/test_convert_batch_norm.py
@@ -128,3 +128,25 @@ def test_convert_batch_norm_default():
     y1 = op_graph(x)
     y2 = simplified_op_graph(x)
     assert np.allclose(y1, y2)
+
+
+def test_convert_batch_norm_non_constant_inputs():
+    bn_size = 3
+    input_op = operations.Input((-1, 3, 5, 5), dtype=np.dtype(np.float64))
+    mean_op = operations.Input((3,), dtype=np.dtype(np.float64))
+    var_op = operations.Input((3,), dtype=np.dtype(np.float64))
+    bn_op = operations.BatchNormalization(
+        input_op,
+        np.random.randn(bn_size).astype(input_op.dtype),
+        np.random.randn(bn_size).astype(input_op.dtype),
+        mean_op,
+        var_op,
+    )
+    op_graph = OperationGraph([bn_op])
+    simplified_op_graph = simplify(op_graph, ConvertBatchNorm(op_graph))
+
+    assert simplified_op_graph.walk(OperationCounter())[0] == 4
+    assert simplified_op_graph.walk(
+        EnsureSupportVisitor([operations.Input, operations.BatchNormalization])
+    )
+    assert simplified_op_graph.output_operations[0] == bn_op


### PR DESCRIPTION
This fixes a couple bugs to address #99. It modifies the TensorflowConverter to visit all input operations to BatchNormalization operations. It also extends the visitor of that converter to handle non-Operation inputs to simplify the implementation of all visitors in the converter. I also modified the ConvertBatchNorm operation graph simplifier to be more general and support batch norm operations over more input op types. I updated the test suite with new tests for both changes. I also renamed one existing test with a duplicate name to another existing test.