### PR TITLE
fix Slice.from_onnx

### DIFF
--- a/dnnv/nn/operations/tensor.py
+++ b/dnnv/nn/operations/tensor.py
@@ -208,7 +208,7 @@ class Slice(Operation):
     @classmethod
     def from_onnx(cls, onnx_node, *inputs):
         attributes = {a.name: as_numpy(a) for a in onnx_node.attribute}
-        return cls(*inputs, name=onnx_node.name)
+        return cls(*inputs, **attributes, name=onnx_node.name)
 
 
 class Tile(Operation):

--- a/tests/unit_tests/test_nn/test_operations/test_base/test_Operation.py
+++ b/tests/unit_tests/test_nn/test_operations/test_base/test_Operation.py
@@ -83,7 +83,7 @@ def test_from_onnx_Slice():
     input_op = Input(np.array([-1, 5]), np.dtype(np.float32))
 
     add_node = onnx.helper.make_node(
-        "Slice", inputs=["input"], outputs=["elu"], name="slice", starts=[0], ends=[1]
+        "Slice", inputs=["input"], outputs=["slice"], name="slice", starts=[0], ends=[1]
     )
     op_from_onnx = Operation.from_onnx(add_node, input_op)
 

--- a/tests/unit_tests/test_nn/test_operations/test_base/test_Operation.py
+++ b/tests/unit_tests/test_nn/test_operations/test_base/test_Operation.py
@@ -79,6 +79,20 @@ def test_from_onnx_Elu():
     assert str(excinfo.value) == "Unimplemented operation type: Fake"
 
 
+def test_from_onnx_Slice():
+    input_op = Input(np.array([-1, 5]), np.dtype(np.float32))
+
+    add_node = onnx.helper.make_node(
+        "Slice", inputs=["input"], outputs=["elu"], name="slice", starts=[0], ends=[1]
+    )
+    op_from_onnx = Operation.from_onnx(add_node, input_op)
+
+    assert type(op_from_onnx) is Slice
+    assert op_from_onnx.x is input_op
+    assert op_from_onnx.starts == [0]
+    assert op_from_onnx.ends == [1]
+
+
 def test_inputs():
     input_op_0 = Input((1, 4), np.dtype(np.float32))
     add_op = Add(input_op_0, np.ones((1, 4), dtype=np.float32))


### PR DESCRIPTION
In the `Slice.to_onnx` method the attributes are ignored. These are needed to initialize the Slice node.
Running a network with a Slice node in its computation graph throws an error 
`TypeError: __init__() missing 2 required positional arguments: 'starts' and 'ends'`  
which is fixed with this pull request.